### PR TITLE
added reSampling function to SNAPBlue

### DIFF
--- a/src/snapblue/SNAPExportTools.py
+++ b/src/snapblue/SNAPExportTools.py
@@ -7,6 +7,7 @@ import shutil
 from mantid.simpleapi import *
 import datetime
 import json
+from snapred.meta.Config import Config
 
 import snapblue.SNAPStateMgr as ssm
 
@@ -19,21 +20,22 @@ class redObject:
     #and then builds further attributes from these
 
 
-    def __init__(self, wsName,exportFormats):
-
-        requiredPrefix = 'reduced_dsp_'
+    def __init__(self, wsName,exportFormats,requiredPrefix='reduced_dsp'):
 
         if '_' not in wsName:
             self.isReducedDataWorkspace = False
             return
 
         parsed = wsName.split('_')
-        prefix = f"{parsed[0]}_{parsed[1]}_"
+        prefix = f"{parsed[0]}_{parsed[1]}"
+        
+        # print(f"prefix: {prefix}, required prefix: {requiredPrefix}")
 
         if prefix != requiredPrefix:
             self.isReducedDataWorkspace = False
             return
         
+        self.suffix = f"{parsed[2]}_{parsed[3]}_{parsed[4]}"
         self.isReducedDataWorkspace = True
         self.pixelGroup = parsed[2]
         self.runNumber = parsed[3]
@@ -48,29 +50,58 @@ class redObject:
         self.exportPaths = self.buildExportPaths()
         self.dateTime = datetime.datetime.strptime(self.timeStamp,'%Y-%m-%dT%H%M%S')
 
-        ws = mtd[wsName]
-        self.instName = ws.getInstrument().getFullName()
-        if "Lite" in self.instName:
-            self.isLite = True
-        else:
-            self.isLite = False
+        #get useful workspace properties
+        self.wsProperties(wsName)
 
         #create a dictionary to hold metadata to include as a comment in output files
 
         if self.isLite:
-            self.redRecord = (f"{self.ipts}shared/SNAPRed/{self.stateID[0]}/"
-                              f"lite/{self.runNumber}/"
-                              f"{self.timeStamp}/")
+            self.redRecord = (f"{self.ipts}shared/SNAPRed/{self.stateID}/"
+                              f"lite/{runNumber}/"
+                              f"{self.timeStamp}/ReductionRecord.json")
         else:
-            self.redRecord = (f"{self.ipts}shared/SNAPRed/{self.stateID[0]}/"
-                              f"native/{self.runNumber}/"
-                              f"{self.timeStamp}/")
+            self.redRecord = (f"{self.ipts}shared/SNAPRed/{self.stateID}/"
+                              f"native/{runNumber}/"
+                              f"{self.timeStamp}/ReductionRecord.json")
 
         self.meta = {
             "redRecord" : self.redRecord, 
             "attenuationMethod": None,
             "backgroundMethod":None
         }
+
+    def wsProperties(self,wsName):
+        #gets some useful attributes of workspace
+
+        ws = mtd[wsName]
+        nPix = ws.getInstrument().getNumberDetectors(True)
+        if nPix == Config["instrument.lite.pixelResolution"]:
+            self.isLite = True
+            self.instName = "SNAPLite"
+        elif nPix == Config["instrument.native.pixelResolution"]:
+            self.isLite = False
+            self.instName = "SNAP"
+        else:
+            print("ERROR: these data aren\'t from a recognised SNAP instrument")
+            assert False
+        
+        self.nHist = ws.getNumberHistograms()
+
+        self.xMin = np.zeros(self.nHist)
+        self.xMax = np.zeros(self.nHist)
+        self.delta = np.zeros(self.nHist)
+        for h in range(self.nHist):
+            x = ws.readX(h)
+            self.xMin[h] = np.min(x)
+            self.xMax[h] = np.max(x)
+            binSizes = x[:-1]-x[1:] #array of bin sizes, one smaller than x array
+            if binSizes[0] == binSizes[-2]:
+                self.binType = "linear"
+                self.delta[h]=binSizes[0]
+            else:
+                self.binType = "logarithmic" #this is not particularly safe...
+                self.delta[h] = -(x[1]/x[0]-1)
+        
 
     def buildExportPaths(self):
 
@@ -179,14 +210,13 @@ def convertToQ():
                         OutputWorkspace=outName,
                         Target="MomentumTransfer")
 
-def reducedRuns(exportFormats,latestOnly=True,gsaInstPrm=True):
+def reducedRuns(exportFormats):#,latestOnly=True,gsaInstPrm=True):
 
     #generates a list of reductionGroups. Each of these has a .runNumber attribute
     #and contains a dictionary with keys for each pixel groups. The corresponding values
     #are a list of available reduction object for that group (each with all attributes needed
     #to export requested files)
 
-    #then works through list and appropriately exports workspaces in each group to disk
 
     allWorkspaces = mtd.getObjectNames()
 
@@ -203,16 +233,22 @@ def reducedRuns(exportFormats,latestOnly=True,gsaInstPrm=True):
     nReduced = len(redObjectList)
     uniqueRuns = set(redRuns)
     nUnique = len(uniqueRuns)
-    print(f"Found total of {nReduced} reduced workspaces these were parsed into {nUnique} reduction groups")
+    print(f"Found total of {nReduced} reduced workspaces these were parsed into {nUnique} run reduction groups")
 
     #parse these creating "reductionGroup" for each run numbner
     reducedGroups = []
     for run in uniqueRuns: 
         redGroup = reductionGroup(run,redObjectList)
         reducedGroups.append(redGroup)
-        exportReducedGroup(redGroup,latestOnly,gsaInstPrm) #this function handles the writing of output files  
 
     return reducedGroups
+
+def exportReducedGroups(reducedGroups,latestOnly=True,gsaInstPrm=True):
+    #works through a reducedGroups list and exports these. Required export formats
+    #must be specified when creating the reducedGroups list
+
+    for redGroup in reducedGroups:
+        exportReducedGroup(redGroup,latestOnly,gsaInstPrm)
 
 def exportReducedGroup(redGroup,latestOnly,gsaInstPrm):
 

--- a/src/snapblue/SNAPStateMgr.py
+++ b/src/snapblue/SNAPStateMgr.py
@@ -9,21 +9,13 @@ import sys
 import copy
 import shutil
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-# SNAPRed imports TODO: clean up what is not needed...
+# SNAPRed imports 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-# from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients
-# from snapred.backend.dao.request import ReductionExportRequest
-# from snapred.backend.dao.request.ReductionRequest import ReductionRequest
+
 from snapred.backend.data.DataFactoryService import DataFactoryService
-# from snapred.backend.error.ContinueWarning import ContinueWarning
-# from snapred.backend.recipe.ReductionRecipe import ReductionRecipe
-# from snapred.backend.service.ReductionService import ReductionService
-# from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.Config import Config
 from snapred.backend.data import LocalDataService as lds
-# from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
-# from snapred.backend.service.SousChef import SousChef
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 
@@ -61,6 +53,15 @@ def stateDef(runNumber):
     }
 
     return [stateID,stateDict]
+
+def retrieveReductionRecord(redRecord):
+    #returns a dictionary taken from the reduction record at path redPath
+
+    with open(redRecord,'r') as file:
+        recordDict = json.load(file)
+    
+    return recordDict
+
 
 def checkStateExists(stateID):
   

--- a/src/snapblue/blueUtils.py
+++ b/src/snapblue/blueUtils.py
@@ -9,9 +9,9 @@ import os
 import shutil
 import importlib
 import snapblue.SNAPStateMgr as ssm
-# importlib.reload(ssm)
+importlib.reload(ssm)
 import snapblue.SNAPExportTools as exportTools
-# importlib.reload(exportTools)
+importlib.reload(exportTools)
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # SNAPRed imports
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -174,12 +174,54 @@ def indexStates(isLite=True):
             print(string) 
 
 
+def resample(sampleFactor=1):
+
+    # function to downsample reduced workspaces
+
+    reducedGroups = exportTools.reducedRuns(exportFormats=[])
+
+    for redGroup in reducedGroups:
+
+        runNumber = redGroup.runNumber
+        runDict = redGroup.objectDict
+        print(f"Down sampling run: {runNumber} with {len(runDict)} pixel group(s)")
+
+        for pgs in runDict.keys():
+            #each key is a pixel group and each pixel group has a list of objects (each is a workspace)
+            print(f"processing group {pgs} with {len(runDict[pgs])} associated workspaces")
+            for redObj in runDict[pgs]:
+                # each redObj corresponds to a mantid workspace containing with reduced data
+
+                XMin = redObj.xMin
+                XMax = redObj.xMax
+                Delta = redObj.delta
+                print("XMin: ",XMin)
+                print("XMax: ",XMax)
+                print("Delta: ",Delta)
+                dsDelta = Delta/sampleFactor #TODO: worry about this sign...
+                print("downSampled Delta: ",dsDelta)
+
+                print(f"inputWorkspace is: {redObj.wsName}")
+                outWSName = f"resampled_dsp_{redObj.suffix}"
+                print(f"outputWorkspace is: {outWSName}")
+                RebinRagged(InputWorkspace=redObj.wsName,
+                            OutputWorkspace=outWSName,
+                            XMin = XMin,
+                            XMax = XMax,
+                            Delta = dsDelta,
+                            )
+
+
+
+
+
 
 def exportData(exportFormats=['gsa','xye','csv'],latestOnly=True,gsaInstPrm=True):
+    #creates reducedGroups and then exports these using the requested export formats
 
-    exportTools.reducedRuns(exportFormats,
-                            latestOnly,
-                            gsaInstPrm)
+    reducedGroups = exportTools.reducedRuns(exportFormats)
+    
+    exportTools.exportReducedGroups(reducedGroups,latestOnly,gsaInstPrm)
     
 def confirmIPTS(ipts,comment="SNAPRed/Blue", subNum=1, redType="Scripts"):
 


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
Data reduced by SNAPRed is binned according to the instrument resolution. But, often times, the sample itself degrades the resolution of the measurement, leading to data that are over-binned. This function allows the users to resample the binning in a consistent way across all pixel groups and sub groups

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->
Existing binning parameters xMin, xMax, and Delta are extracted from the individual histograms in the reduced workspaces themselves. The resampling works via using a single user-specified parameter "sampleFactor" that divides Delta for all histograms. Thus sampleFactor < 1 will reduce sampling, sampleFactor == 1 will leave sampling unchanged and sampleFactor >1 will increase sampling.

Note this approach means sampleFactor directly scales the number of points across the FWHM, so samplefactor=0.5 will mean half the number of bins across the FWHM. 

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
