### PR TITLE
added function to hide specified workspaces in a workspace group

### DIFF
--- a/src/snapblue/SNAPExportTools.py
+++ b/src/snapblue/SNAPExportTools.py
@@ -35,8 +35,14 @@ class redObject:
             self.isReducedDataWorkspace = False
             return
         
-        self.suffix = f"{parsed[2]}_{parsed[3]}_{parsed[4]}"
+        #get useful workspace properties
+        self.wsProperties(wsName)
+        if not self.isReducedDataWorkspace:
+            return
+        
         self.isReducedDataWorkspace = True
+
+        self.suffix = f"{parsed[2]}_{parsed[3]}_{parsed[4]}"
         self.pixelGroup = parsed[2]
         self.runNumber = parsed[3]
         self.timeStamp = parsed[4]
@@ -50,8 +56,7 @@ class redObject:
         self.exportPaths = self.buildExportPaths()
         self.dateTime = datetime.datetime.strptime(self.timeStamp,'%Y-%m-%dT%H%M%S')
 
-        #get useful workspace properties
-        self.wsProperties(wsName)
+        
 
         #create a dictionary to hold metadata to include as a comment in output files
 
@@ -78,12 +83,16 @@ class redObject:
         if nPix == Config["instrument.lite.pixelResolution"]:
             self.isLite = True
             self.instName = "SNAPLite"
+            self.isReducedDataWorkspace = True
         elif nPix == Config["instrument.native.pixelResolution"]:
             self.isLite = False
             self.instName = "SNAP"
+            self.isReducedDataWorkspace = True
         else:
             print("ERROR: these data aren\'t from a recognised SNAP instrument")
-            assert False
+            print(f"found {nPix} pixels in instrument for workspace {wsName}")
+            self.isReducedDataWorkspace=False
+            return
         
         self.nHist = ws.getNumberHistograms()
 
@@ -107,7 +116,7 @@ class redObject:
 
         #TODO: use elements of paths defined in SNAPInstPrm instead of hardwiring here
         #TODO: allow for overrides?
-        #TODO: save reduction metadata? Link to reduction record?
+        #TODO: save reduction metadata? Link to reduction
 
         #constructs export filepaths according to exportFormats requested
 

--- a/src/snapblue/blueUtils.py
+++ b/src/snapblue/blueUtils.py
@@ -173,12 +173,62 @@ def indexStates(isLite=True):
         if statuses[i] == "*CALIB*":
             print(string) 
 
+def file(nameKeys,operation="add",cabinetName="File_Cabinet"):
+
+#creates a Workspace Group called cabinetName.
+# if operation = "add" workspaces with specified nameKeys in their name will be added to group
+# if operation = "remove" workspaces with specified nameKeys in their name will be removed from group
+# if operation = "empty" cabinet will be emptied and removed
+ 
+    if operation.lower() == "empty":
+        groupWS = mtd[cabinetName]
+        UnGroupWorkspace(groupWS)
+        return
+
+    # print("nameKeys: ",nameKeys)
+    if type(nameKeys) != list:
+        print("ERROR: name keys must be a list")
+        return
+
+    allWorkspaces = mtd.getObjectNames()
+    toBeFiled = []
+    for wsName in allWorkspaces:
+        for key in nameKeys:
+            if key.lower() in wsName.lower():
+                toBeFiled.append(wsName)
+
+    if operation.lower() == "add":
+        print(f"{len(toBeFiled)} workspaces will be added to {cabinetName}")
+        # check if filing cabinet exists already 
+        if mtd.doesExist(cabinetName):
+            wsGroup = mtd[cabinetName]
+            cabinetContents = wsGroup.getNames()
+            for wsName in toBeFiled:
+                wsGroup.add(wsName)
+
+        else:
+            GroupWorkspaces(InputWorkspaces=toBeFiled,
+                        OutputWOrkspace=cabinetName)
+
+    if operation.lower() == "remove":
+        if not mtd.doesExist(cabinetName):
+            print(f"{cabinetName} doesn\'t exist cannot remove from it")
+            return
+        
+        print(f"{len(toBeFiled)} workspaces will be removed from {cabinetName}")
+        wsGroup = mtd[cabinetName]
+        for wsName in toBeFiled:
+            wsGroup.remove(wsName)
+
+
+    wsGroup = mtd[cabinetName]
+    print(f"{cabinetName} has {wsGroup.getNumberOfEntries()} total workspaces")
 
 def resample(sampleFactor=1):
 
     # function to downsample reduced workspaces
 
-    reducedGroups = exportTools.reducedRuns(exportFormats=[])
+    reducedGroups = exportTools.reducedRuns(exportFormats=[],prefix="reduced_dsp")
 
     for redGroup in reducedGroups:
 
@@ -191,7 +241,7 @@ def resample(sampleFactor=1):
             print(f"processing group {pgs} with {len(runDict[pgs])} associated workspaces")
             for redObj in runDict[pgs]:
                 # each redObj corresponds to a mantid workspace containing with reduced data
-
+                print(redObj.redRecord)
                 XMin = redObj.xMin
                 XMax = redObj.xMax
                 Delta = redObj.delta


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
This is a small helper function that uses mantid's workspace groups to to hide unneeded workspaces from sight to keep the tree clean. It has options to retrieve these as needed.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
