### PR TITLE
Cycle dates

### DIFF
--- a/scripts/testCycleDates.py
+++ b/scripts/testCycleDates.py
@@ -1,0 +1,43 @@
+"""Workbench test script for cycleDates functionality.
+
+Usage (from the SNAPWrap repo root):
+    env=/SNS/SNAP/shared/Malcolm/test/snapwrap/v2.0.0.yml pixi run python -m workbench
+
+Then open this script in the Workbench script editor and run it.
+
+What this script does:
+  1. Builds the JSON index from the .ods spreadsheet in the test
+     calibration directory.
+  2. Prints all known cycles.
+  3. Looks up several run numbers and prints their cycle assignments.
+"""
+
+from snapwrap.cycleDates import build_cycle_json, load_cycle_data, get_cycle_for_run, clear_cache
+from snapwrap.snapStateMgr import cycleForRun
+
+# ── Step 1: Build the JSON index from the .ods ──────────────────────────
+print("=" * 60)
+print("Building cycle-dates JSON index from .ods spreadsheet …")
+print("=" * 60)
+
+records = build_cycle_json()
+print(f"\n✓ Indexed {len(records)} cycles.\n")
+
+# ── Step 2: Show all cycles ─────────────────────────────────────────────
+print(f"{'cycleID':<12}  {'startDate':<12}  {'stopDate':<12}  {'firstRun':>10}")
+print("-" * 52)
+for rec in records:
+    fr = rec["firstRun"] if rec["firstRun"] is not None else "—"
+    print(f"{rec['cycleID']:<12}  {rec['startDate']:<12}  {rec['stopDate']:<12}  {str(fr):>10}")
+
+# ── Step 3: Look up some run numbers ────────────────────────────────────
+test_runs = [52862, 55208, 57463, 58842, 61326, 64030, 66539, 99999, 1]
+
+print("\n" + "=" * 60)
+print("Run-number → cycle lookups")
+print("=" * 60)
+for run in test_runs:
+    cycle = cycleForRun(run)
+    print(f"  run {run:>6}  →  {cycle}")
+
+print("\nDone.")

--- a/src/snapwrap/_version.py
+++ b/src/snapwrap/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.2.0rc2"
+__version__ = "2.2.0rc3"

--- a/src/snapwrap/cycleDates.py
+++ b/src/snapwrap/cycleDates.py
@@ -1,0 +1,339 @@
+"""cycleDates  –  map SNAP run numbers to facility operating cycles.
+
+Workflow
+--------
+1. Instrument scientists maintain a LibreOffice Calc spreadsheet (.ods) with
+   columns: cycleID, startDate, stopDate, firstRun.
+   Rows may appear in any order (the module sorts by startDate).
+   Future cycles whose firstRun is not yet known should have a blank/NaN
+   firstRun; these rows are stored in the JSON but excluded from run-number
+   lookups.
+2. ``build_cycle_json()`` reads that spreadsheet, validates the data and writes
+   a versioned JSON file to a standard location.
+3. ``get_cycle_for_run(run_number)`` performs a fast lookup against the cached
+   JSON data to return the cycle ID for a given run.
+
+Paths default to ``{Config["instrument.calibration.home"]}/cycleDates.{ods,json}``
+but can be overridden.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from snapred.meta.Config import Config
+
+# ---------------------------------------------------------------------------
+# Default paths
+# ---------------------------------------------------------------------------
+_CAL_HOME: str = Config["instrument.calibration.home"]
+DEFAULT_ODS: str = os.path.join(_CAL_HOME, "cycleDates.ods")
+DEFAULT_JSON: str = os.path.join(_CAL_HOME, "cycleDates.json")
+
+# ---------------------------------------------------------------------------
+# Module-level cache (populated once per session unless explicitly rebuilt)
+# ---------------------------------------------------------------------------
+_CYCLE_CACHE: Optional[List[Dict[str, Any]]] = None
+_CACHE_VERSION: Optional[int] = None
+
+# Expected spreadsheet columns
+_REQUIRED_COLUMNS = {"cycleID", "startDate", "stopDate", "firstRun"}
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date(val: Any, label: str, row_idx: int) -> datetime.date:
+    """Parse a value as YYYY-MM-DD, raising ValueError with context on failure.
+
+    Accepts ``datetime.date``, ``datetime.datetime``, pandas ``Timestamp``,
+    or an ISO-format string.
+    """
+    if isinstance(val, datetime.datetime):
+        return val.date()
+    if isinstance(val, datetime.date):
+        return val
+    s = str(val).strip()
+    try:
+        return datetime.date.fromisoformat(s)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"Row {row_idx}: '{label}' value '{val}' is not a valid YYYY-MM-DD date"
+        )
+
+
+def _validate_dataframe(df: pd.DataFrame) -> List[Dict[str, Any]]:
+    """Validate a DataFrame read from the .ods and return a list of cycle dicts.
+
+    The DataFrame is sorted by startDate ascending before validation so the
+    spreadsheet rows need not be in any particular order.
+
+    Rows whose ``firstRun`` is blank / NaN are treated as future cycles: they
+    are included in the output (with ``firstRun: null``) but skipped during
+    overlap and monotonicity checks on firstRun.
+
+    Checks performed:
+    - Required columns present.
+    - No duplicate cycleIDs.
+    - Dates parse as YYYY-MM-DD and stopDate >= startDate.
+    - firstRun values (when present) are positive integers.
+    - After sorting, no overlapping date ranges.
+    - firstRun values are monotonically increasing (consistent with date order).
+    """
+    # --- column check ---
+    missing = _REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        raise ValueError(f"Spreadsheet missing required columns: {sorted(missing)}")
+
+    # drop completely empty rows that Calc sometimes appends
+    df = df.dropna(how="all").reset_index(drop=True)
+
+    if df.empty:
+        raise ValueError("Spreadsheet contains no data rows")
+
+    # --- sort by startDate ascending ---
+    # parse dates into a temporary column for sorting, then iterate in order
+    df = df.copy()
+    df["_start_parsed"] = [
+        _parse_date(row["startDate"], "startDate", i) for i, row in df.iterrows()
+    ]
+    df = df.sort_values("_start_parsed").reset_index(drop=True)
+
+    # --- per-row validation ---
+    records: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+    prev_end: Optional[datetime.date] = None
+    prev_first_run: Optional[int] = None
+
+    for i, row in df.iterrows():
+        cycle_id = str(row["cycleID"]).strip()
+        if cycle_id in seen_ids:
+            raise ValueError(f"Row {i}: duplicate cycleID '{cycle_id}'")
+        seen_ids.add(cycle_id)
+
+        start = _parse_date(row["startDate"], "startDate", i)
+        stop = _parse_date(row["stopDate"], "stopDate", i)
+        if stop < start:
+            raise ValueError(
+                f"Row {i} ('{cycle_id}'): stopDate ({stop}) < startDate ({start})"
+            )
+
+        # firstRun — may be NaN for future cycles
+        raw_first = row["firstRun"]
+        first_run: Optional[int] = None
+        if pd.notna(raw_first):
+            try:
+                first_run = int(raw_first)
+            except (ValueError, TypeError):
+                raise ValueError(
+                    f"Row {i} ('{cycle_id}'): firstRun '{raw_first}' is not a valid integer"
+                )
+            if first_run < 1:
+                raise ValueError(
+                    f"Row {i} ('{cycle_id}'): firstRun must be a positive integer, got {first_run}"
+                )
+
+        # no overlapping date ranges
+        if prev_end is not None and start <= prev_end:
+            raise ValueError(
+                f"Row {i} ('{cycle_id}'): startDate ({start}) overlaps with previous cycle "
+                f"stopDate ({prev_end})"
+            )
+
+        # firstRun monotonically increasing (skip when either is None)
+        if first_run is not None and prev_first_run is not None and first_run <= prev_first_run:
+            raise ValueError(
+                f"Row {i} ('{cycle_id}'): firstRun ({first_run}) must be greater than "
+                f"previous firstRun ({prev_first_run})"
+            )
+
+        records.append({
+            "cycleID": cycle_id,
+            "startDate": start.isoformat(),
+            "stopDate": stop.isoformat(),
+            "firstRun": first_run,
+        })
+
+        prev_end = stop
+        if first_run is not None:
+            prev_first_run = first_run
+
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_cycle_json(
+    ods_path: Optional[str] = None,
+    json_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Read the .ods spreadsheet, validate, write versioned JSON, and update cache.
+
+    Parameters
+    ----------
+    ods_path : str, optional
+        Path to the LibreOffice Calc spreadsheet.  Defaults to
+        ``{calibration.home}/cycleDates.ods``.
+    json_path : str, optional
+        Destination for the JSON file.  Defaults to
+        ``{calibration.home}/cycleDates.json``.
+
+    Returns
+    -------
+    list[dict]
+        The validated list of cycle records (also cached in-module).
+    """
+    global _CYCLE_CACHE, _CACHE_VERSION
+
+    ods_path = ods_path or DEFAULT_ODS
+    json_path = json_path or DEFAULT_JSON
+
+    if not os.path.isfile(ods_path):
+        raise FileNotFoundError(f"Cycle-dates spreadsheet not found: {ods_path}")
+
+    df = pd.read_excel(ods_path, engine="odf")
+    records = _validate_dataframe(df)
+
+    # Determine version: bump if an existing JSON already exists
+    new_version = 1
+    if os.path.isfile(json_path):
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                existing = json.load(fh)
+            new_version = int(existing.get("version", 0)) + 1
+        except Exception:
+            new_version = 1
+
+    payload = {
+        "version": new_version,
+        "generated": datetime.datetime.now().isoformat(timespec="seconds"),
+        "source": str(ods_path),
+        "cycles": records,
+    }
+
+    Path(json_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+
+    print(f"cycleDates: wrote {len(records)} cycle(s) to {json_path} (version {new_version})")
+
+    # refresh module cache
+    _CYCLE_CACHE = records
+    _CACHE_VERSION = new_version
+
+    return records
+
+
+def load_cycle_data(
+    json_path: Optional[str] = None,
+    rebuild: bool = False,
+    ods_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return the list of cycle records, loading from JSON (or rebuilding from .ods).
+
+    The result is cached for the lifetime of the Python session.  Pass
+    ``rebuild=True`` to force a re-read of the .ods spreadsheet, re-validate
+    and rewrite the JSON.
+
+    Parameters
+    ----------
+    json_path : str, optional
+        Path to the JSON file.
+    rebuild : bool
+        If True, re-reads the .ods and regenerates the JSON before loading.
+    ods_path : str, optional
+        Path to the .ods (only used when *rebuild* is True).
+
+    Returns
+    -------
+    list[dict]
+        Cycle records sorted by firstRun ascending.
+    """
+    global _CYCLE_CACHE, _CACHE_VERSION
+
+    if rebuild:
+        return build_cycle_json(ods_path=ods_path, json_path=json_path)
+
+    if _CYCLE_CACHE is not None:
+        return _CYCLE_CACHE
+
+    json_path = json_path or DEFAULT_JSON
+
+    if not os.path.isfile(json_path):
+        raise FileNotFoundError(
+            f"Cycle JSON not found at {json_path}. "
+            "Run build_cycle_json() first to generate it from the .ods spreadsheet."
+        )
+
+    with open(json_path, "r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    _CYCLE_CACHE = payload.get("cycles", [])
+    _CACHE_VERSION = int(payload.get("version", 1))
+    return _CYCLE_CACHE
+
+
+def get_cycle_for_run(
+    run_number: int,
+    rebuild: bool = False,
+    json_path: Optional[str] = None,
+) -> Optional[str]:
+    """Return the cycleID that contains *run_number*, or None if not found.
+
+    Lookup strategy: the cycle whose ``firstRun <= run_number`` and whose
+    successor's ``firstRun > run_number`` (or is the last cycle) is the match.
+
+    Parameters
+    ----------
+    run_number : int
+        The SNAP run number to look up.
+    rebuild : bool
+        If True, force a rebuild from the .ods before looking up.
+    json_path : str, optional
+        Path to the JSON file.
+
+    Returns
+    -------
+    str or None
+        The cycleID, or None if the run predates all recorded cycles.
+    """
+    run_number = int(run_number)
+    cycles = load_cycle_data(json_path=json_path, rebuild=rebuild)
+
+    if not cycles:
+        return None
+
+    # cycles are sorted by startDate ascending (guaranteed by validation).
+    # Skip cycles with null firstRun (future cycles not yet started).
+    match: Optional[str] = None
+    for cycle in cycles:
+        fr = cycle["firstRun"]
+        if fr is None:
+            continue  # future cycle – no run-number assignment yet
+        if run_number >= fr:
+            match = cycle["cycleID"]
+        else:
+            break  # all subsequent cycles have higher firstRun
+
+    return match
+
+
+def cache_version() -> Optional[int]:
+    """Return the version number of the currently cached cycle data, or None."""
+    return _CACHE_VERSION
+
+
+def clear_cache() -> None:
+    """Clear the in-memory cycle cache so the next lookup re-reads from disk."""
+    global _CYCLE_CACHE, _CACHE_VERSION
+    _CYCLE_CACHE = None
+    _CACHE_VERSION = None

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -22,6 +22,8 @@ from snapred.backend.data import LocalDataService as lds
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 
+from snapwrap.cycleDates import get_cycle_for_run, build_cycle_json, load_cycle_data
+
 
 class SNAPHome():
    # main definition of calibration directory
@@ -735,3 +737,33 @@ def frankenRecord(donorRun,
         print(franken.workspaces)
 
     return franken
+
+
+# ---------------------------------------------------------------------------
+# Cycle-date helpers
+# ---------------------------------------------------------------------------
+
+def cycleForRun(runNumber):
+    """Return the facility operating-cycle ID for a given SNAP run number.
+
+    Parameters
+    ----------
+    runNumber : int or str
+        The run number to look up.
+
+    Returns
+    -------
+    str or None
+        The cycleID (e.g. ``'2025-A'``), or ``None`` if the run
+        predates all recorded cycles.
+
+    Notes
+    -----
+    On first call the module reads (or builds) a JSON index from the
+    ``cycleDates.ods`` spreadsheet in the calibration directory.
+    Subsequent calls use the in-memory cache.
+    """
+    cycle = get_cycle_for_run(runNumber)
+    if cycle is None:
+        print(f"cycleDates: no cycle found for run {runNumber}")
+    return cycle

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -84,10 +84,14 @@ def checkStateExists(stateID):
 
   return os.path.exists(statePath)
 
-def matchingCalibrationIndex(calIndexList, runNumber):
+def matchingCalibrationIndex(calIndexList, runNumber, requiredCycleID=None):
 
     # accept a presorted list of calibration index entries and a run number. Find the most recent
-    # entry that has an "appliesTo" attribute that is consisten with runNumber
+    # entry that has an "appliesTo" attribute that is consistent with runNumber.
+    #
+    # If requiredCycleID is not None, additionally require that the entry's
+    # "cycleID" key matches requiredCycleID.  Entries without a "cycleID" key
+    # are treated as matching (backwards-compatible).
 
     # Define allowed operators
     ops = {
@@ -121,12 +125,15 @@ def matchingCalibrationIndex(calIndexList, runNumber):
             op_str, value_str = match_obj.groups()
             value = int(value_str)
 
-            # print("runNumber:",type(runNumber))
-            # print("value", type(value))
-
             if not ops[op_str](runNumber, value):
                 match = False
                 break
+
+        # If appliesTo matched, optionally enforce cycle restriction
+        if match and requiredCycleID is not None:
+            entryCycle = entry.get("cycleID")
+            if entryCycle is not None and entryCycle != requiredCycleID:
+                match = False
 
         if match:
             return original_index
@@ -186,7 +193,7 @@ def dateFromLinux(ts):
 
     return datetime.fromtimestamp(int(ts)).strftime('%Y-%m-%d %H:%M:%S')
     
-def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal"):
+def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal",requireSameCycle=True):
 
     # checks either difcal or normcal calibrations for a given state and `isLite` setting. Returns dictionary of useful
     # properties regarding these.
@@ -199,7 +206,11 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
     # a stateID must be provided. If a runNumber is provided, it is not necessary to provide a stateID
 
     # To distinguish between most recent calibration versus most recent _valid_ calibration, additional keys are now added
-    # and their names made more explicit  
+    # and their names made more explicit
+
+    # If requireSameCycle is True (default), a calibration is only considered valid for a run if the calibration's
+    # run number belongs to the same facility operating cycle as the input run number. Set to False to allow
+    # out-of-cycle calibrations to be used (legacy behaviour).
 
     #try to fix incoming typos and case errors
     nrmAlt = ["nrmcal"]
@@ -261,7 +272,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = {}
         calStatus["latestValidCalibrationDate"] = "never"
         calStatus["latestValidCalibrationDict"] = {}
-        # print(f"Run: {runNumber} corresponds to stateID: {stateID}. This state does not exist so run is uncalibrated")
+        calStatus["statusDetail"] = "state does not exist"
         
         return calStatus
 
@@ -275,7 +286,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = {}
         calStatus["latestValidCalibrationDate"] = "never"
         calStatus["latestValidCalibrationDict"] = {}
-        # print(f"Run: {runNumber} corresponds to stateID: {stateID}. State exists but has no normcal")
+        calStatus["statusDetail"] = "state exists but has no normalization index"
         
         return calStatus
 
@@ -299,7 +310,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = calIndexList[0] # still need to have default index entry
         calStatus["latestValidCalibrationDate"] = "never"
         calStatus["latestValidCalibrationDict"] = {}
-        # print(f"Run: {runNumber} corresponds to stateID: {stateID}. This state exists but only has default difcal")
+        calStatus["statusDetail"] = "state exists but only has default (geometric) difcal"
         
         return calStatus
 
@@ -328,7 +339,18 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
                       reverse=True
                       )
 
+    # Annotate every index entry with its cycleID (looked up from runNumber)
+    for entry in calIndexList:
+        if "cycleID" not in entry:
+            entry["cycleID"] = get_cycle_for_run(entry["runNumber"])
+
     calStatus["calibIndexList"] = calIndexList
+
+    # Determine the cycle for the input run number (None if runNumber is None)
+    runCycleID = None
+    if runNumber is not None:
+        runCycleID = get_cycle_for_run(runNumber)
+    calStatus["runCycleID"] = runCycleID
 
     # If no runnumber only obtainable information relates to general state calibrations so return
     # with this
@@ -341,6 +363,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = calStatus["calibIndexList"][0]
         calStatus["latestValidCalibrationDate"] = "never"
         calStatus["latestValidCalibrationDict"] = {}
+        calStatus["statusDetail"] = "no run number provided; general state info only"
         if calType == "normcal":
             calStatus["latestVBRunNumber"] = VBRunNumberFromVersion(calStatus["latestCalibrationDict"],calStatus["calFolder"])
             calStatus["latestValidVBRunNumber"] = None
@@ -348,9 +371,11 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         return calStatus
 
     # Now examine list of existing calibrations in order of date to find the most recent valid one considering the provided
-    # run number. 
+    # run number. The cycle of the calibration must also match the cycle of the input run (if known) unless
+    # requireSameCycle is False.
 
-    validIndex = matchingCalibrationIndex(calStatus["calibIndexList"], runNumber)
+    effectiveCycleID = runCycleID if requireSameCycle else None
+    validIndex = matchingCalibrationIndex(calStatus["calibIndexList"], runNumber, requiredCycleID=effectiveCycleID)
 
     if validIndex is None:
 
@@ -361,6 +386,22 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = calStatus["calibIndexList"][0]
         calStatus["latestValidCalibrationDate"] = "never"
         calStatus["latestValidCalibrationDict"] = {}
+
+        # Determine *why* no valid calibration was found
+        if requireSameCycle and runCycleID is not None:
+            # Re-check without the cycle filter to see if appliesTo alone would have matched
+            noCycleIndex = matchingCalibrationIndex(calStatus["calibIndexList"], runNumber, requiredCycleID=None)
+            if noCycleIndex is not None:
+                calStatus["statusDetail"] = (
+                    f"valid calibration exists but is out of cycle "
+                    f"(run cycle: {runCycleID}, "
+                    f"calibration cycle: {calStatus['calibIndexList'][noCycleIndex].get('cycleID', '?')})"
+                )
+            else:
+                calStatus["statusDetail"] = "calibrations exist but no matching run range in appliesTo"
+        else:
+            calStatus["statusDetail"] = "calibrations exist but no matching run range in appliesTo"
+
         if calType == "normcal":
             calStatus["latestVBRunNumber"] = VBRunNumberFromVersion(calStatus["latestCalibrationDict"],calStatus["calFolder"])
             calStatus["latestValidVBRunNumber"] = None
@@ -377,6 +418,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal")
         calStatus["latestCalibrationDict"] = calStatus["calibIndexList"][0]
         calStatus["latestValidCalibrationDate"] = calStatus["calibIndexList"][validIndex]["timestamp"].split(".")[0]
         calStatus["latestValidCalibrationDict"] = calStatus["calibIndexList"][validIndex]
+        calStatus["statusDetail"] = "valid calibration found"
         if calType == "normcal":
             calStatus["latestVBRunNumber"] = VBRunNumberFromVersion(calStatus["latestCalibrationDict"],calStatus["calFolder"])
             calStatus["latestValidVBRunNumber"] = VBRunNumberFromVersion(calStatus["latestValidCalibrationDict"],calStatus["calFolder"])

--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -123,6 +123,7 @@ def reloadRedConfig(path=None):
 
     if path is None:
         Config.reload() # reloads original config according to environment
+        Config.reload(os.environ.get("env")) # needed to correctly retain a user specified env
         print("Original SNAPRed config reloaded")
     else:
         # confirm file exists at path
@@ -132,6 +133,7 @@ def reloadRedConfig(path=None):
         else:
             Config.reload(path) # reloads specified override file
             print(f"SNAPRed config override applied")
+            Config.reload(os.environ.get("env")) # needed to correctly retain a user specified env
     return
 
 def filterLite(runNumber, boundaries, **reduce_kwargs):

--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -427,22 +427,28 @@ def indexStates(isLite=True):
 
         if difcal['latestCalibrationDate'] != "never":
             latestDifcalRun = difcal['latestCalibrationDict']['runNumber']
+            latestDifcalCycle = ssm.cycleForRun(latestDifcalRun) or ""
         else:
             latestDifcalRun = ""
+            latestDifcalCycle = ""
 
         nNrmcal = nrmcal['numberCalibrations']
 
         if nrmcal['latestCalibrationDate'] != "never":
             latestNrmcalRun = nrmcal['latestCalibrationDict']['runNumber']
             latestNrmcalBack = nrmcal['latestVBRunNumber']
+            latestNrmcalCycle = ssm.cycleForRun(latestNrmcalRun) or ""
+            latestNrmcalBackCycle = ssm.cycleForRun(latestNrmcalBack) or ""
         else:
             latestNrmcalRun = ""
             latestNrmcalBack = ""
+            latestNrmcalCycle = ""
+            latestNrmcalBackCycle = ""
 
         outputString = (f"{stateID}|{desc}|"
                         f" {calStatus} |"
-                        f"     {nDifcal}     | {latestDifcalRun.rjust(6)} |"
-                        f"     {nNrmcal}     | {latestNrmcalRun.rjust(6)} | {latestNrmcalBack.rjust(6)} |"
+                        f"     {nDifcal}     | {latestDifcalCycle.rjust(6)} |"
+                        f"     {nNrmcal}     | {latestNrmcalCycle.rjust(6)} | {latestNrmcalBackCycle.rjust(6)} |"
                             )
         statuses.append(calStatus) 
         outputStrings.append(outputString)

--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -1381,12 +1381,6 @@ def restoreDBins(redObj,originalIngredients):
     #extract ragged binning params from originalIngredients
 
     pgName = redObj.pixelGroup.lower()
-    # print(f"Debug: restoring dbinning for pixel group: {pgName}")
-    # print("DEBUG: originalIngredients contains the following pixel groups: ")
-    print([pg.focusGroup.name for pg in originalIngredients])
-    print("here is the complete original ingredients:")
-    for pg in originalIngredients:
-        print(pg)
 
     dMins = []
     dMaxs = []
@@ -1922,28 +1916,22 @@ def reduce(runNumber,
             hooks = hooks,
         )
 
-
-    # # manually add focus groups to the request.
-    # reductionRequest.focusGroups = groupings["focusGroups"]
-
-    # # print("groupings are: ")
-    # # print(groupings)
-    # # print("should be a valid list [type=list_type, input_value={'focusGroups': [FocusGro...rouping__Column_64413']}, input_type=dict]")
-    # # assert False
+    # manually add focus groups to the request.
+    groupings = reductionService.fetchReductionGroupings(reductionRequest)
+    pgs = groupings["focusGroups"]
+    reductionRequest.focusGroups = pgs
 
     # # print("Debug 1866, pixel group allow list = ",reductionRequest.focusGroupAllowList)
 
     snapRequest = SNAPRequest(path="/reduction",payload=reductionRequest,hooks=hooks)
     reductionService.validateReduction(reductionRequest)
+    # manually add focus groups to the request.
+    groupings = reductionService.fetchReductionGroupings(reductionRequest)
+    pgs = groupings["focusGroups"]
+    reductionRequest.focusGroups = pgs
 
     print("snapRequest:")
     print(snapRequest)
-
-
-
-
-    
-
 
     # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     # "fetchReductionGroceries" Loads necessary data (e.g. sample neutron data,
@@ -1970,6 +1958,7 @@ def reduce(runNumber,
 
     ingredients = reductionService.prepReductionIngredients(reductionRequest)
     ingredients.artificialNormalizationIngredients = artificialNormalizationIngredients
+
 
     # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     # Determine calibration status and process this
@@ -2060,15 +2049,14 @@ def reduce(runNumber,
         originalIngredients,ingredients = updateBinForQ(ingredients,linBin)
 
         pgs = ingredients.pixelGroups
-        print("UPDATED")
+
         for pg in pgs:
-            print(f"pgs: {pg.focusGroup.name} with {len(pg.pixelGroupingParameters)} subgroups")
+
             for subgroup in pg.pixelGroupingParameters:
                 params = pg.pixelGroupingParameters[subgroup]
                 dMin = params.dResolution.minimum
                 dMax = params.dResolution.maximum
                 dBin = params.dRelativeResolution/pg.nBinsAcrossPeakWidth
-                print(f"{dMin:.4f} {dBin:.6f} {dMax:.4f}")
 
     if reduceData:
 

--- a/tests/test_calibration_status.py
+++ b/tests/test_calibration_status.py
@@ -1,0 +1,479 @@
+"""Tests for cycle-aware calibration status in snapwrap.snapStateMgr.
+
+These tests exercise:
+1. Annotation of calibration index entries with ``cycleID``.
+2. The new ``runCycleID`` key in the returned calStatus dictionary.
+3. The cycle-match criterion: ``runIsCalibrated`` is ``False`` when the
+   calibration's cycleID differs from the input run's cycleID, even if
+   the ``appliesTo`` expression would otherwise be satisfied.
+4. ``matchingCalibrationIndex`` with an optional *requiredCycleID*
+   parameter.
+5. The ``statusDetail`` key explaining *why* a calibration is or isn't valid.
+
+Heavy mocking is used so that no real disk state or SNAPRed services are
+needed.
+"""
+
+import json
+import io
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+import snapwrap.snapStateMgr as ssm
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_index_entry(
+    version: int,
+    runNumber: str,
+    appliesTo: str,
+    timestamp: str,
+    useLiteMode: bool = True,
+    comments: str = "",
+    author: str = "test",
+):
+    """Return a dict that looks like a CalibrationIndex entry."""
+    return {
+        "version": version,
+        "runNumber": runNumber,
+        "useLiteMode": useLiteMode,
+        "appliesTo": appliesTo,
+        "timestamp": timestamp,
+        "comments": comments,
+        "author": author,
+    }
+
+
+def _json_file_factory(data):
+    """Return a *callable* that produces a fresh StringIO context-manager
+    containing *data* serialised as JSON every time it is called.
+
+    Use with ``patch("builtins.open", side_effect=_json_file_factory(data))``.
+    Each call to ``open()`` inside the production code will get a brand-new
+    StringIO, preventing 'I/O operation on closed file' errors when
+    ``checkCalibrationStatus`` opens more than one file.
+    """
+    content = json.dumps(data)
+
+    def _factory(*args, **kwargs):
+        sio = io.StringIO(content)
+        sio.__enter__ = lambda s: s
+        sio.__exit__ = lambda s, *a: None
+        return sio
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# matchingCalibrationIndex
+# ---------------------------------------------------------------------------
+
+class TestMatchingCalibrationIndex:
+    """Verify existing + new cycle-filter behaviour of matchingCalibrationIndex."""
+
+    def _entries(self):
+        return [
+            _make_index_entry(1, "50000", ">=50000", "2024-01-15T10:00:00.000"),
+            _make_index_entry(2, "60000", ">=60000", "2024-06-15T10:00:00.000"),
+            _make_index_entry(3, "70000", ">=70000", "2025-01-15T10:00:00.000"),
+        ]
+
+    def test_match_first_entry(self):
+        idx = ssm.matchingCalibrationIndex(self._entries(), 55000)
+        assert idx == 0
+
+    def test_match_second_entry(self):
+        idx = ssm.matchingCalibrationIndex(self._entries(), 65000)
+        assert idx == 1
+
+    def test_match_third_entry(self):
+        idx = ssm.matchingCalibrationIndex(self._entries(), 75000)
+        assert idx == 2
+
+    def test_no_match(self):
+        idx = ssm.matchingCalibrationIndex(self._entries(), 40000)
+        assert idx is None
+
+    def test_cycle_filter_skips_wrong_cycle(self):
+        entries = self._entries()
+        entries[0]["cycleID"] = "2024-A"
+        entries[1]["cycleID"] = "2024-B"
+        entries[2]["cycleID"] = "2025-A"
+        idx = ssm.matchingCalibrationIndex(entries, 75000, requiredCycleID="2024-B")
+        assert idx == 1
+
+    def test_cycle_filter_no_match_when_no_cycle_matches(self):
+        entries = self._entries()
+        entries[0]["cycleID"] = "2024-A"
+        entries[1]["cycleID"] = "2024-B"
+        entries[2]["cycleID"] = "2025-A"
+        idx = ssm.matchingCalibrationIndex(entries, 75000, requiredCycleID="2023-B")
+        assert idx is None
+
+    def test_cycle_filter_none_means_no_restriction(self):
+        entries = self._entries()
+        entries[0]["cycleID"] = "2024-A"
+        entries[1]["cycleID"] = "2024-B"
+        entries[2]["cycleID"] = "2025-A"
+        idx = ssm.matchingCalibrationIndex(entries, 75000, requiredCycleID=None)
+        assert idx == 2
+
+
+# ---------------------------------------------------------------------------
+# checkCalibrationStatus -- cycle annotation & runCycleID
+# ---------------------------------------------------------------------------
+
+class TestCheckCalibrationStatusCycleAnnotation:
+
+    def _make_difcal_index(self):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-06-01T10:00:00.000")
+        v2 = _make_index_entry(2, "62000", ">=60000", "2025-01-01T10:00:00.000")
+        return [default, v1, v2]
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_index_entries_annotated_with_cycleID(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        index_data = self._make_difcal_index()
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 62000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=63000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        for entry in result["calibIndexList"]:
+            assert "cycleID" in entry, f"Entry v{entry['version']} missing cycleID"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_runCycleID_present(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        index_data = self._make_difcal_index()
+        mock_gcfr.return_value = "2024-B"
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=63000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        assert "runCycleID" in result
+        assert result["runCycleID"] == "2024-B"
+
+
+# ---------------------------------------------------------------------------
+# checkCalibrationStatus -- cycle validity criterion
+# ---------------------------------------------------------------------------
+
+class TestCheckCalibrationStatusCycleValidity:
+
+    def _make_difcal_index(self):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        return [default, v1]
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_same_cycle_is_calibrated(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        index_data = self._make_difcal_index()
+        mock_gcfr.return_value = "2024-A"
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=56000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        assert result["runIsCalibrated"] is True
+        assert result["statusDetail"] == "valid calibration found"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_cross_cycle_not_calibrated(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        index_data = self._make_difcal_index()
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 60000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=62000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        assert result["runIsCalibrated"] is False
+        assert "out of cycle" in result["statusDetail"]
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_cross_cycle_falls_back_to_same_cycle_entry(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        v2 = _make_index_entry(2, "62000", ">=50000", "2024-09-01T10:00:00.000")
+        index_data = [default, v1, v2]
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 60000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=56000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        assert result["runIsCalibrated"] is True
+        assert result["latestValidCalibrationDict"]["version"] == 1
+        assert result["statusDetail"] == "valid calibration found"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_runNumber_none_skips_cycle_check(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        index_data = [default, v1]
+        mock_gcfr.return_value = "2024-A"
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=None, stateID="abc123", isLite=True, calType="difcal"
+            )
+
+        assert result.get("runCycleID") is None
+        for entry in result["calibIndexList"]:
+            assert "cycleID" in entry
+        assert result["statusDetail"] == "no run number provided; general state info only"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_cycle_none_treated_as_no_restriction(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        index_data = [default, v1]
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn == 56000:
+                return None
+            return "2024-A"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=56000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        assert result["runIsCalibrated"] is True
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_requireSameCycle_false_allows_cross_cycle(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        index_data = [default, v1]
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 60000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=62000, stateID=None, isLite=True, calType="difcal",
+                requireSameCycle=False
+            )
+
+        assert result["runIsCalibrated"] is True
+        assert result["latestValidCalibrationDict"]["version"] == 1
+        assert result["statusDetail"] == "valid calibration found"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_requireSameCycle_true_rejects_cross_cycle(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        index_data = [default, v1]
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 60000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=62000, stateID=None, isLite=True, calType="difcal",
+                requireSameCycle=True
+            )
+
+        assert result["runIsCalibrated"] is False
+        assert "out of cycle" in result["statusDetail"]
+
+
+# ---------------------------------------------------------------------------
+# checkCalibrationStatus -- statusDetail key
+# ---------------------------------------------------------------------------
+
+class TestCheckCalibrationStatusStatusDetail:
+
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=False)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_state_does_not_exist(self, mock_stateDef, mock_stateExists):
+        result = ssm.checkCalibrationStatus(
+            runNumber=55000, stateID=None, isLite=True, calType="difcal"
+        )
+        assert result["statusDetail"] == "state does not exist"
+
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_normcal_no_index_file(self, mock_stateDef, mock_stateExists):
+        with patch("os.path.isfile", return_value=False):
+            result = ssm.checkCalibrationStatus(
+                runNumber=55000, stateID=None, isLite=True, calType="normcal"
+            )
+        assert result["statusDetail"] == "state exists but has no normalization index"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run", return_value="2024-A")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_difcal_only_default(self, mock_stateDef, mock_stateExists, mock_gcfr):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        index_data = [default]
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=55000, stateID=None, isLite=True, calType="difcal"
+            )
+        assert result["statusDetail"] == "state exists but only has default (geometric) difcal"
+
+    @patch("snapwrap.snapStateMgr.VBRunNumberFromVersion", return_value="99999")
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_appliesTo_mismatch(self, mock_stateDef, mock_stateExists, mock_gcfr, mock_vb):
+        """Use normcal (no catch-all default) with thresholds above the query run."""
+        mock_gcfr.return_value = "2024-A"
+
+        v1 = _make_index_entry(1, "55000", ">=55000", "2024-03-01T10:00:00.000")
+        v2 = _make_index_entry(2, "60000", ">=60000", "2024-06-01T10:00:00.000")
+        index_data = [v1, v2]
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=52000, stateID=None, isLite=True, calType="normcal"
+            )
+        assert result["runIsCalibrated"] is False
+        assert result["statusDetail"] == "calibrations exist but no matching run range in appliesTo"
+
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_out_of_cycle_detail_contains_both_cycles(
+        self, mock_stateDef, mock_stateExists, mock_gcfr
+    ):
+        default = _make_index_entry(0, "50000", ">=0", "2024-01-01T00:00:00.000")
+        v1 = _make_index_entry(1, "55000", ">=50000", "2024-03-01T10:00:00.000")
+        index_data = [default, v1]
+
+        def cycle_side_effect(rn):
+            rn = int(rn)
+            if rn < 60000:
+                return "2024-A"
+            return "2024-B"
+
+        mock_gcfr.side_effect = cycle_side_effect
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=62000, stateID=None, isLite=True, calType="difcal"
+            )
+
+        detail = result["statusDetail"]
+        assert "out of cycle" in detail
+        assert "2024-B" in detail
+        assert "2024-A" in detail
+
+    @patch("snapwrap.snapStateMgr.VBRunNumberFromVersion", return_value="99999")
+    @patch("snapwrap.snapStateMgr.get_cycle_for_run")
+    @patch("snapwrap.snapStateMgr.checkStateExists", return_value=True)
+    @patch("snapwrap.snapStateMgr.stateDef", return_value=["abc123", {}])
+    def test_requireSameCycle_false_appliesTo_mismatch(
+        self, mock_stateDef, mock_stateExists, mock_gcfr, mock_vb
+    ):
+        """Use normcal (no catch-all default) so query run genuinely fails appliesTo."""
+        mock_gcfr.return_value = "2024-A"
+
+        v1 = _make_index_entry(1, "55000", ">=55000", "2024-03-01T10:00:00.000")
+        v2 = _make_index_entry(2, "60000", ">=60000", "2024-06-01T10:00:00.000")
+        index_data = [v1, v2]
+
+        with patch("builtins.open", side_effect=_json_file_factory(index_data)), \
+             patch("os.path.isfile", return_value=True):
+            result = ssm.checkCalibrationStatus(
+                runNumber=52000, stateID=None, isLite=True, calType="normcal",
+                requireSameCycle=False
+            )
+        assert result["runIsCalibrated"] is False
+        assert result["statusDetail"] == "calibrations exist but no matching run range in appliesTo"

--- a/tests/test_cycle_dates.py
+++ b/tests/test_cycle_dates.py
@@ -1,0 +1,299 @@
+"""Tests for snapwrap.cycleDates
+
+These tests use tmp_path fixtures and mock ``pd.read_excel`` so neither
+the ``odf`` library nor a real instrument calibration directory are needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import snapwrap.cycleDates as cd
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _good_rows() -> list[dict]:
+    """Return a valid minimal set of cycle rows (in chronological order)."""
+    return [
+        {"cycleID": "2024-A", "startDate": "2024-01-15", "stopDate": "2024-06-30", "firstRun": 50000},
+        {"cycleID": "2024-B", "startDate": "2024-07-15", "stopDate": "2024-12-31", "firstRun": 52000},
+        {"cycleID": "2025-A", "startDate": "2025-01-15", "stopDate": "2025-06-30", "firstRun": 55000},
+    ]
+
+
+def _good_rows_reversed() -> list[dict]:
+    """Same data as _good_rows but in reverse order (like the real spreadsheet)."""
+    return list(reversed(_good_rows()))
+
+
+def _good_rows_with_future() -> list[dict]:
+    """Rows including a future cycle whose firstRun is NaN."""
+    return _good_rows() + [
+        {"cycleID": "2025-B", "startDate": "2025-07-15", "stopDate": "2025-12-31", "firstRun": float("nan")},
+    ]
+
+
+def _write_json(path: Path, rows: list[dict], version: int = 1) -> str:
+    """Write a cycle-dates JSON file and return its path string."""
+    jp = str(path / "cycleDates.json")
+    payload = {
+        "version": version,
+        "generated": "2025-01-01T00:00:00",
+        "source": str(path / "cycleDates.ods"),
+        "cycles": rows,
+    }
+    with open(jp, "w") as fh:
+        json.dump(payload, fh, indent=2)
+    return jp
+
+
+def _ods_sentinel(path: Path) -> str:
+    """Create an empty file to satisfy the os.path.isfile check for the .ods."""
+    fp = str(path / "cycleDates.ods")
+    Path(fp).touch()
+    return fp
+
+
+def _mock_read_excel(rows: list[dict]):
+    """Return a side_effect callable that ignores args and returns a DataFrame."""
+    def _read(*args, **kwargs):
+        return pd.DataFrame(rows)
+    return _read
+
+
+# ---------------------------------------------------------------------------
+# Validation tests  (no I/O needed, just DataFrames)
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+
+    def test_missing_column_raises(self):
+        df = pd.DataFrame([{"cycleID": "A", "startDate": "2024-01-01", "stopDate": "2024-06-01"}])
+        with pytest.raises(ValueError, match="missing required columns"):
+            cd._validate_dataframe(df)
+
+    def test_empty_dataframe_raises(self):
+        df = pd.DataFrame(columns=["cycleID", "startDate", "stopDate", "firstRun"])
+        with pytest.raises(ValueError, match="no data rows"):
+            cd._validate_dataframe(df)
+
+    def test_bad_date_raises(self):
+        df = pd.DataFrame([{
+            "cycleID": "X", "startDate": "not-a-date", "stopDate": "2024-06-01", "firstRun": 1
+        }])
+        with pytest.raises(ValueError, match="not a valid YYYY-MM-DD"):
+            cd._validate_dataframe(df)
+
+    def test_stop_before_start_raises(self):
+        df = pd.DataFrame([{
+            "cycleID": "X", "startDate": "2024-06-01", "stopDate": "2024-01-01", "firstRun": 1
+        }])
+        with pytest.raises(ValueError, match="stopDate.*< startDate"):
+            cd._validate_dataframe(df)
+
+    def test_non_integer_firstRun_raises(self):
+        df = pd.DataFrame([{
+            "cycleID": "X", "startDate": "2024-01-01", "stopDate": "2024-06-01", "firstRun": "abc"
+        }])
+        with pytest.raises(ValueError, match="not a valid integer"):
+            cd._validate_dataframe(df)
+
+    def test_negative_firstRun_raises(self):
+        df = pd.DataFrame([{
+            "cycleID": "X", "startDate": "2024-01-01", "stopDate": "2024-06-01", "firstRun": -5
+        }])
+        with pytest.raises(ValueError, match="positive integer"):
+            cd._validate_dataframe(df)
+
+    def test_duplicate_cycleID_raises(self):
+        df = pd.DataFrame([
+            {"cycleID": "A", "startDate": "2024-01-01", "stopDate": "2024-06-01", "firstRun": 1},
+            {"cycleID": "A", "startDate": "2024-07-01", "stopDate": "2024-12-01", "firstRun": 100},
+        ])
+        with pytest.raises(ValueError, match="duplicate cycleID"):
+            cd._validate_dataframe(df)
+
+    def test_overlapping_dates_raises(self):
+        df = pd.DataFrame([
+            {"cycleID": "A", "startDate": "2024-01-01", "stopDate": "2024-07-01", "firstRun": 1},
+            {"cycleID": "B", "startDate": "2024-07-01", "stopDate": "2024-12-01", "firstRun": 100},
+        ])
+        with pytest.raises(ValueError, match="overlaps"):
+            cd._validate_dataframe(df)
+
+    def test_firstRun_not_increasing_raises(self):
+        df = pd.DataFrame([
+            {"cycleID": "A", "startDate": "2024-01-01", "stopDate": "2024-06-01", "firstRun": 200},
+            {"cycleID": "B", "startDate": "2024-07-01", "stopDate": "2024-12-01", "firstRun": 100},
+        ])
+        with pytest.raises(ValueError, match="must be greater"):
+            cd._validate_dataframe(df)
+
+    def test_valid_data_passes(self):
+        df = pd.DataFrame(_good_rows())
+        records = cd._validate_dataframe(df)
+        assert len(records) == 3
+        assert records[0]["cycleID"] == "2024-A"
+        assert records[-1]["firstRun"] == 55000
+
+    def test_reverse_order_is_sorted(self):
+        """Rows supplied in reverse chronological order are sorted correctly."""
+        df = pd.DataFrame(_good_rows_reversed())
+        records = cd._validate_dataframe(df)
+        assert [r["cycleID"] for r in records] == ["2024-A", "2024-B", "2025-A"]
+
+    def test_nan_firstRun_accepted_for_future_cycle(self):
+        """A NaN firstRun is allowed (future cycle) and stored as None."""
+        df = pd.DataFrame(_good_rows_with_future())
+        records = cd._validate_dataframe(df)
+        assert len(records) == 4
+        future = records[-1]
+        assert future["cycleID"] == "2025-B"
+        assert future["firstRun"] is None
+
+    def test_pandas_timestamp_dates_accepted(self):
+        """Dates arriving as pandas Timestamps (as from .ods read) are handled."""
+        rows = [
+            {"cycleID": "X", "startDate": pd.Timestamp("2024-01-15"),
+             "stopDate": pd.Timestamp("2024-06-30"), "firstRun": 100},
+        ]
+        records = cd._validate_dataframe(pd.DataFrame(rows))
+        assert records[0]["startDate"] == "2024-01-15"
+
+
+# ---------------------------------------------------------------------------
+# build / load / lookup integration tests
+# ---------------------------------------------------------------------------
+
+class TestBuildAndLookup:
+
+    def setup_method(self):
+        cd.clear_cache()
+
+    @patch("snapwrap.cycleDates.pd.read_excel", side_effect=_mock_read_excel(_good_rows()))
+    def test_build_writes_json(self, _mock_read, tmp_path):
+        ods = _ods_sentinel(tmp_path)
+        json_path = str(tmp_path / "cycleDates.json")
+
+        records = cd.build_cycle_json(ods_path=ods, json_path=json_path)
+        assert len(records) == 3
+
+        with open(json_path, "r") as fh:
+            payload = json.load(fh)
+        assert payload["version"] == 1
+        assert len(payload["cycles"]) == 3
+        assert "generated" in payload
+        assert "source" in payload
+
+    @patch("snapwrap.cycleDates.pd.read_excel", side_effect=_mock_read_excel(_good_rows()))
+    def test_version_bumps_on_rebuild(self, _mock_read, tmp_path):
+        ods = _ods_sentinel(tmp_path)
+        json_path = str(tmp_path / "cycleDates.json")
+
+        cd.build_cycle_json(ods_path=ods, json_path=json_path)
+        cd.build_cycle_json(ods_path=ods, json_path=json_path)
+
+        with open(json_path) as fh:
+            payload = json.load(fh)
+        assert payload["version"] == 2
+
+    @patch("snapwrap.cycleDates.pd.read_excel", side_effect=_mock_read_excel(_good_rows()))
+    def test_load_from_json(self, _mock_read, tmp_path):
+        ods = _ods_sentinel(tmp_path)
+        json_path = str(tmp_path / "cycleDates.json")
+        cd.build_cycle_json(ods_path=ods, json_path=json_path)
+        cd.clear_cache()
+
+        data = cd.load_cycle_data(json_path=json_path)
+        assert len(data) == 3
+        assert isinstance(cd.cache_version(), int)
+
+    @patch("snapwrap.cycleDates.pd.read_excel", side_effect=_mock_read_excel(_good_rows()))
+    def test_load_uses_cache(self, _mock_read, tmp_path):
+        ods = _ods_sentinel(tmp_path)
+        json_path = str(tmp_path / "cycleDates.json")
+        cd.build_cycle_json(ods_path=ods, json_path=json_path)
+
+        # delete the json to prove cache is used (not re-read)
+        Path(json_path).unlink()
+        data = cd.load_cycle_data(json_path=json_path)
+        assert len(data) == 3
+
+    def test_load_missing_json_raises(self, tmp_path):
+        cd.clear_cache()
+        with pytest.raises(FileNotFoundError, match="Cycle JSON not found"):
+            cd.load_cycle_data(json_path=str(tmp_path / "nope.json"))
+
+    def test_rebuild_flag(self, tmp_path):
+        """rebuild=True re-reads the .ods (mocked) and writes a new JSON."""
+        rows = _good_rows()
+        validated = cd._validate_dataframe(pd.DataFrame(rows))
+        json_path = _write_json(tmp_path, validated, version=1)
+        cd.load_cycle_data(json_path=json_path)   # prime the cache
+
+        rows_extended = rows + [
+            {"cycleID": "2025-B", "startDate": "2025-07-15", "stopDate": "2025-12-31", "firstRun": 58000}
+        ]
+        ods = _ods_sentinel(tmp_path)
+        with patch("snapwrap.cycleDates.pd.read_excel", side_effect=_mock_read_excel(rows_extended)):
+            data = cd.load_cycle_data(json_path=json_path, rebuild=True, ods_path=ods)
+        assert len(data) == 4
+
+
+class TestGetCycleForRun:
+
+    def setup_method(self):
+        cd.clear_cache()
+
+    def _setup(self, tmp_path) -> str:
+        """Write a pre-validated JSON fixture and prime the cache."""
+        validated = cd._validate_dataframe(pd.DataFrame(_good_rows()))
+        jp = _write_json(tmp_path, validated)
+        cd.load_cycle_data(json_path=jp)
+        return jp
+
+    def test_run_in_first_cycle(self, tmp_path):
+        jp = self._setup(tmp_path)
+        assert cd.get_cycle_for_run(50000, json_path=jp) == "2024-A"
+        assert cd.get_cycle_for_run(51999, json_path=jp) == "2024-A"
+
+    def test_run_in_second_cycle(self, tmp_path):
+        jp = self._setup(tmp_path)
+        assert cd.get_cycle_for_run(52000, json_path=jp) == "2024-B"
+        assert cd.get_cycle_for_run(54999, json_path=jp) == "2024-B"
+
+    def test_run_in_last_cycle(self, tmp_path):
+        jp = self._setup(tmp_path)
+        assert cd.get_cycle_for_run(55000, json_path=jp) == "2025-A"
+        assert cd.get_cycle_for_run(99999, json_path=jp) == "2025-A"
+
+    def test_run_before_all_cycles(self, tmp_path):
+        jp = self._setup(tmp_path)
+        assert cd.get_cycle_for_run(1, json_path=jp) is None
+        assert cd.get_cycle_for_run(49999, json_path=jp) is None
+
+    def test_run_at_exact_boundary(self, tmp_path):
+        jp = self._setup(tmp_path)
+        # firstRun of cycle 2 is 52000 → should be in cycle 2
+        assert cd.get_cycle_for_run(52000, json_path=jp) == "2024-B"
+
+    def test_accepts_string_run_number(self, tmp_path):
+        jp = self._setup(tmp_path)
+        assert cd.get_cycle_for_run("53000", json_path=jp) == "2024-B"
+
+    def test_future_cycle_skipped(self, tmp_path):
+        """Cycles with null firstRun are ignored during lookup."""
+        cd.clear_cache()
+        validated = cd._validate_dataframe(pd.DataFrame(_good_rows_with_future()))
+        jp = _write_json(tmp_path, validated)
+        cd.load_cycle_data(json_path=jp)
+        # run 99999 should still map to 2025-A, not the future 2025-B
+        assert cd.get_cycle_for_run(99999, json_path=jp) == "2025-A"


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

Following a request from Chris, this PR establishes a cycleID as a property of any run. It also enforces a match between the calue of cycleID for a run and any calibration applied to it. 

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

The basis of the cycle allocation is an ODF file that must be manually created and maintained by IS's. This recourse was needed as a) there is currently no global record of this (oncat, express, ipts systems were investigated as possible sources, but they do not track this) and b) the exact "start of cycle" is made fuzzy by common "soft starts". The Instrument scientists are considered to be best placed to judge what the most appropriate date to use it. Note: precision is only by day, not time.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
