### PR TITLE
Corrupt calibrations

### DIFF
--- a/scripts/build_reduction_tally.py
+++ b/scripts/build_reduction_tally.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+"""Crawl all IPTS folders and build a tally of reduced runs per state.
+
+Each reduced run is classified as **auto** or **manual** by comparing the
+mtime of the autoreduce log with the mtime of the reduced-run folder.
+If the two are within ``AUTO_THRESHOLD_SECONDS`` (default 120 s) the run
+is considered an autoreduction; otherwise it is manual.
+
+Output
+------
+Writes a JSON file to {calibration_home}/reductionTally.json with structure::
+
+    {
+        "generated": "2026-03-10T...",
+        "ipts_scanned": 546,
+        "ipts_with_reductions": 12,
+        "states": {
+            "<stateID>": {
+                "total_runs": 42,
+                "auto_runs": 38,
+                "manual_runs": 4,
+                "ipts": {
+                    "37478": {
+                        "runs": {
+                            "68984": "auto",
+                            "68985": "auto",
+                            "68986": "manual"
+                        }
+                    },
+                    ...
+                }
+            },
+            ...
+        }
+    }
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+
+SNAP_ROOT = "/SNS/SNAP"
+# Allow override for testing
+CALIB_HOME = os.environ.get("CALIB_HOME", "/SNS/SNAP/shared/Calibration")
+OUTPUT_PATH = os.path.join(CALIB_HOME, "reductionTally.json")
+
+# Maximum time difference (seconds) between autoreduce log mtime and
+# reduced-folder mtime to classify a run as auto-reduced.
+AUTO_THRESHOLD_SECONDS = 120
+
+
+def classify_run(ipts_num, state_id, run_number, run_folder_path):
+    """Classify a reduced run as 'auto' or 'manual'.
+
+    Compares the mtime of the autoreduce log file with the mtime of the
+    reduced-run folder.  If the difference is within AUTO_THRESHOLD_SECONDS
+    the run is classified as 'auto'; otherwise 'manual'.  If the log file
+    does not exist the run is classified as 'manual' (no autoreduction
+    evidence).
+    """
+    log_path = os.path.join(
+        SNAP_ROOT,
+        f"IPTS-{ipts_num}",
+        "shared",
+        "autoreduce",
+        "reduction_log",
+        f"SNAP_{run_number}.nxs.h5.log",
+    )
+
+    if not os.path.exists(log_path):
+        return "manual"
+
+    try:
+        log_mtime = os.path.getmtime(log_path)
+        folder_mtime = os.path.getmtime(run_folder_path)
+        diff = abs(log_mtime - folder_mtime)
+        return "auto" if diff <= AUTO_THRESHOLD_SECONDS else "manual"
+    except OSError:
+        return "manual"
+
+
+def main():
+    print(f"Scanning IPTS folders under {SNAP_ROOT} ...")
+    print(f"Output will be written to: {OUTPUT_PATH}")
+    print(f"Auto-threshold: {AUTO_THRESHOLD_SECONDS} seconds")
+    print()
+
+    # Gather all IPTS directories
+    all_entries = sorted(os.listdir(SNAP_ROOT))
+    ipts_dirs = [e for e in all_entries if e.startswith("IPTS-")]
+    print(f"Found {len(ipts_dirs)} IPTS folders")
+
+    tally = {}       # stateID -> { "total_runs": int, "auto_runs": int, "manual_runs": int,
+                     #               "ipts": { ipts_num: { "runs": { run: "auto"|"manual" } } } }
+    ipts_scanned = 0
+    ipts_with_reductions = 0
+    errors = []
+    global_auto = 0
+    global_manual = 0
+
+    for i, ipts_name in enumerate(ipts_dirs):
+        ipts_num = ipts_name.split("-")[1]
+        snapred_dir = os.path.join(SNAP_ROOT, ipts_name, "shared", "SNAPRed")
+
+        ipts_scanned += 1
+
+        if not os.path.isdir(snapred_dir):
+            continue
+
+        ipts_with_reductions += 1
+
+        # Each subdirectory of SNAPRed is a stateID (skip 'export' and other non-state dirs)
+        try:
+            state_dirs = os.listdir(snapred_dir)
+        except PermissionError as e:
+            errors.append(f"Permission denied: {snapred_dir}")
+            continue
+        except Exception as e:
+            errors.append(f"Error listing {snapred_dir}: {e}")
+            continue
+
+        for state_name in state_dirs:
+            # State IDs are 16-char hex strings
+            if len(state_name) != 16:
+                continue
+
+            state_path = os.path.join(snapred_dir, state_name)
+            if not os.path.isdir(state_path):
+                continue
+
+            # Look inside lite/ for run folders
+            lite_path = os.path.join(state_path, "lite")
+            use_lite = os.path.isdir(lite_path)
+            if not use_lite:
+                # Maybe runs are directly inside the state folder?
+                # Check for numeric subdirectories
+                try:
+                    contents = os.listdir(state_path)
+                    runs = [c for c in contents if c.isdigit()]
+                except PermissionError:
+                    errors.append(f"Permission denied: {state_path}")
+                    continue
+                if not runs:
+                    continue
+            else:
+                try:
+                    contents = os.listdir(lite_path)
+                    runs = [c for c in contents if c.isdigit()]
+                except PermissionError:
+                    errors.append(f"Permission denied: {lite_path}")
+                    continue
+
+            if not runs:
+                continue
+
+            if state_name not in tally:
+                tally[state_name] = {"total_runs": 0, "auto_runs": 0, "manual_runs": 0, "ipts": {}}
+
+            # Classify each run and determine its folder path
+            run_classifications = {}
+            for run in sorted(runs):
+                # Determine the actual folder path for the run
+                if use_lite:
+                    run_folder = os.path.join(lite_path, run)
+                else:
+                    run_folder = os.path.join(state_path, run)
+                kind = classify_run(ipts_num, state_name, run, run_folder)
+                run_classifications[run] = kind
+
+            auto_count = sum(1 for v in run_classifications.values() if v == "auto")
+            manual_count = len(run_classifications) - auto_count
+
+            tally[state_name]["ipts"][ipts_num] = {"runs": run_classifications}
+            tally[state_name]["total_runs"] += len(run_classifications)
+            tally[state_name]["auto_runs"] += auto_count
+            tally[state_name]["manual_runs"] += manual_count
+            global_auto += auto_count
+            global_manual += manual_count
+
+        # Progress
+        if (i + 1) % 50 == 0 or (i + 1) == len(ipts_dirs):
+            print(f"  scanned {i + 1}/{len(ipts_dirs)} IPTS folders "
+                  f"({ipts_with_reductions} with reductions, "
+                  f"{len(tally)} states seen so far)")
+
+    print()
+    print(f"Scan complete.")
+    print(f"  IPTS scanned:          {ipts_scanned}")
+    print(f"  IPTS with reductions:  {ipts_with_reductions}")
+    print(f"  Unique states found:   {len(tally)}")
+
+    total_runs = sum(s["total_runs"] for s in tally.values())
+    print(f"  Total reduced runs:    {total_runs}")
+    print(f"    Auto-reduced:        {global_auto}")
+    print(f"    Manually reduced:    {global_manual}")
+
+    if errors:
+        print(f"\n  Errors ({len(errors)}):")
+        for e in errors:
+            print(f"    {e}")
+
+    # Sort by total_runs descending for readability
+    sorted_states = dict(sorted(tally.items(), key=lambda x: x[1]["total_runs"], reverse=True))
+
+    output = {
+        "generated": datetime.now().isoformat(),
+        "ipts_scanned": ipts_scanned,
+        "ipts_with_reductions": ipts_with_reductions,
+        "unique_states": len(tally),
+        "total_reduced_runs": total_runs,
+        "total_auto_runs": global_auto,
+        "total_manual_runs": global_manual,
+        "auto_threshold_seconds": AUTO_THRESHOLD_SECONDS,
+        "states": sorted_states,
+    }
+
+    with open(OUTPUT_PATH, "w") as fh:
+        json.dump(output, fh, indent=2)
+    print(f"\nTally written to: {OUTPUT_PATH}")
+
+    # Print top-15 summary
+    print("\nTop states by reduction count:")
+    print(f"  {'stateID':>16s}  {'total':>5s} {'auto':>5s} {'manual':>6s}  IPTS")
+    for sid, info in list(sorted_states.items())[:15]:
+        n_ipts = len(info["ipts"])
+        print(f"  {sid}  {info['total_runs']:5d} {info['auto_runs']:5d} {info['manual_runs']:6d}  {n_ipts}")
+
+    # States with only auto-reduced runs (never manually reduced)
+    auto_only = sorted(
+        [(sid, info) for sid, info in tally.items() if info["manual_runs"] == 0 and info["total_runs"] > 0],
+        key=lambda x: x[1]["total_runs"],
+        reverse=True,
+    )
+    if auto_only:
+        print(f"\nStates with ONLY auto-reduced runs (0 manual): {len(auto_only)}")
+        for sid, info in auto_only:
+            print(f"  {sid}  {info['total_runs']:5d} auto runs across {len(info['ipts'])} IPTS")
+
+    # Print states with 0 reductions (from calibration home)
+    calib_powder = os.path.join(CALIB_HOME, "Powder")
+    if os.path.isdir(calib_powder):
+        all_calib_states = {
+            d for d in os.listdir(calib_powder)
+            if os.path.isdir(os.path.join(calib_powder, d)) and len(d) == 16
+        }
+        never_reduced = sorted(all_calib_states - set(tally.keys()))
+        print(f"\nCalibration states with ZERO reductions: {len(never_reduced)}")
+        for sid in never_reduced:
+            print(f"  {sid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_legacy_detail.py
+++ b/scripts/check_legacy_detail.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Check all 15 legacy states for indexEntry presence across all versions."""
+
+import json
+import os
+
+legacy = [
+    "094b3bf778349fee", "3621a8676e0e95ae", "62b9099189f81ae8",
+    "7297ac31012d83de", "7410ea64254694c9", "7422d766b5893dd4",
+    "80f82b45769ad9ec", "81e22e8767d1fc1a", "8f9d8c3d5da04688",
+    "a35f211c6bd58df7", "a37270be5816403b", "c61b49105432efb1",
+    "c8625d33d276a1f5", "e013e1a9933e9852", "e99bec2493aec83d",
+]
+
+calib = "/SNS/SNAP/shared/Calibration/Powder"
+
+for sid in legacy:
+    base = f"{calib}/{sid}/lite/diffraction"
+    idx = json.load(open(f"{base}/CalibrationIndex.json"))
+
+    version_info = []
+    for ie in idx:
+        v = ie["version"]
+        folder = f"{base}/v_{str(v).zfill(4)}"
+        rec_path = f"{folder}/CalibrationRecord.json"
+        par_path = f"{folder}/CalibrationParameters.json"
+
+        rec_ie = "-"
+        par_ie = "-"
+        if os.path.isfile(rec_path):
+            rec = json.load(open(rec_path))
+            rec_ie = "Y" if "indexEntry" in rec else "N"
+        if os.path.isfile(par_path):
+            par = json.load(open(par_path))
+            par_ie = "Y" if "indexEntry" in par else "N"
+
+        version_info.append(f"v{v}(rec={rec_ie} par={par_ie})")
+
+    # normcal
+    norm_path = f"{calib}/{sid}/lite/normalization/NormalizationIndex.json"
+    norm_info = "no normcal"
+    if os.path.isfile(norm_path):
+        nidx = json.load(open(norm_path))
+        nv_parts = []
+        for nie in nidx:
+            nv = nie["version"]
+            nf = f"{calib}/{sid}/lite/normalization/v_{str(nv).zfill(4)}"
+            nrec_ie = "-"
+            npar_ie = "-"
+            nrec_p = f"{nf}/NormalizationRecord.json"
+            npar_p = f"{nf}/NormalizationParameters.json"
+            if os.path.isfile(nrec_p):
+                nrec_ie = "Y" if "indexEntry" in json.load(open(nrec_p)) else "N"
+            if os.path.isfile(npar_p):
+                npar_ie = "Y" if "indexEntry" in json.load(open(npar_p)) else "N"
+            nv_parts.append(f"v{nv}(rec={nrec_ie} par={npar_ie})")
+        norm_info = " ".join(nv_parts)
+
+    print(f"{sid}  difcal: {' '.join(version_info)}")
+    print(f"{'':18s}  normcal: {norm_info}")

--- a/scripts/dry_run_fix.py
+++ b/scripts/dry_run_fix.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Dry-run fixIndex on one example of each failure type."""
+
+import snapwrap.snapStateMgr as ssm
+
+# Type 1: appliesTo mismatch (04bd2c53f6bf6754)
+print("=== TYPE 1: appliesTo mismatch ===")
+print("State: 04bd2c53f6bf6754")
+print()
+result = ssm.fixIndex(stateID="04bd2c53f6bf6754", calType="difcal", dryRun=True, autoConfirm=True)
+for a in result["actions"]:
+    print(a)
+print()
+print("=" * 72)
+print()
+
+# Type 2: orphaned folder (22744cf05aaf2a8f)
+print("=== TYPE 2: orphaned folder ===")
+print("State: 22744cf05aaf2a8f")
+print()
+result = ssm.fixIndex(stateID="22744cf05aaf2a8f", calType="difcal", dryRun=True, autoConfirm=True)
+for a in result["actions"]:
+    print(a)
+print()
+print("=" * 72)
+print()
+
+# Type 3: wrong filename / corrupt data (03c116b0df7506d9)
+print("=== TYPE 3: wrong filename (corrupt data) ===")
+print("State: 03c116b0df7506d9")
+print()
+result = ssm.fixIndex(stateID="03c116b0df7506d9", calType="difcal", dryRun=True, autoConfirm=True)
+for a in result["actions"]:
+    print(a)

--- a/scripts/fix_e1512.py
+++ b/scripts/fix_e1512.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+"""Fix e1512a39893ebc99 in test env."""
+import snapwrap.snapStateMgr as ssm
+ssm.fixIndex(stateID="e1512a39893ebc99", calType="difcal", dryRun=False, autoConfirm=True)

--- a/scripts/identify_transient_states.py
+++ b/scripts/identify_transient_states.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+"""Identify transient calibration states that can be safely deleted.
+
+Criteria for a transient state:
+  a) Only the default v0 calibration exists (no real calibrations) AND
+     no normalization index exists.
+  b) State has never been used to **manually** reduce data (0 manual runs
+     in reductionTally.json).  Auto-reductions are discounted because the
+     autoreduction service creates junk output for uncalibrated states.
+  c) State has existed for at least one full cycle (i.e. was created before
+     the start of the current cycle).
+
+Usage
+-----
+    python scripts/identify_transient_states.py              # list only
+    python scripts/identify_transient_states.py --delete     # delete after confirmation
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from datetime import datetime
+
+
+CALIB_HOME = os.environ.get("CALIB_HOME", "/SNS/SNAP/shared/Calibration")
+POWDER_HOME = os.path.join(CALIB_HOME, "Powder")
+TALLY_PATH = os.path.join(CALIB_HOME, "reductionTally.json")
+
+# Current cycle start — states created before this are "at least one cycle old"
+# Update this when a new cycle begins.
+CURRENT_CYCLE_START = datetime(2026, 1, 1)  # 2026-A started Jan 2026
+
+# Abbreviated PV names for human-readable state labels
+_PV_ABBREV = {
+    "det_arc1": "arc1",
+    "det_arc2": "arc2",
+    "BL3:Chop:Skf1:WavelengthUserReq": "wav",
+    "BL3:Det:TH:BL:Frequency": "freq",
+    "BL3:Mot:OpticsPos:Pos": "pos",
+    "BL3:Mot:OpticsPos:ExitSlit": "slit",
+    # legacy key names
+    "vdet_arc1": "arc1",
+    "vdet_arc2": "arc2",
+    "WavelengthUserReq": "wav",
+    "Frequency": "freq",
+    "Pos": "pos",
+    "slit": "slit",
+}
+
+
+def pull_state_label(state_id):
+    """Return a human-readable label for *state_id* from its v0 CalibrationParameters.
+
+    Mirrors the logic of ``pullStateDict`` + ``autoStateName`` in snapStateMgr
+    but reads files directly (no mantid dependency).
+    """
+    params_path = os.path.join(
+        POWDER_HOME, state_id, "lite", "diffraction", "v_0000", "CalibrationParameters.json"
+    )
+    try:
+        with open(params_path, "r") as fh:
+            params = json.load(fh)
+    except Exception:
+        return "(unable to read state)"
+
+    det = params.get("instrumentState", {}).get("detectorState", {})
+
+    # SNAPRed ≥ v2.0.0 format: PVs dict
+    if "PVs" in det:
+        pvs = dict(det["PVs"])
+        pvs.pop("det_lin1", None)
+        pvs.pop("det_lin2", None)
+        if "BL3:Det:TH:BL:Frequency" in pvs:
+            pvs["BL3:Det:TH:BL:Frequency"] = float(pvs["BL3:Det:TH:BL:Frequency"])
+    else:
+        # v1.3.0 format
+        pvs = {
+            "det_arc1": float(round(det["arc"][0] * 2) / 2),
+            "det_arc2": float(round(det["arc"][1] * 2) / 2),
+            "BL3:Chop:Skf1:WavelengthUserReq": float(round(det["wav"], 1)),
+            "BL3:Det:TH:BL:Frequency": float(round(det["freq"])),
+            "BL3:Mot:OpticsPos:Pos": int(det["guideStat"]),
+        }
+
+    parts = []
+    for key, val in pvs.items():
+        abbr = _PV_ABBREV.get(key, key)
+        if abbr.startswith("arc"):
+            parts.append(f"{abbr}:{val:6.1f}")
+        else:
+            parts.append(f"{abbr}:{val}")
+    return "::".join(parts)
+
+
+def oldest_file_mtime(directory):
+    """Return the earliest mtime of any file under *directory*."""
+    oldest = None
+    for root, dirs, files in os.walk(directory):
+        for f in files:
+            fp = os.path.join(root, f)
+            try:
+                mt = os.path.getmtime(fp)
+                if oldest is None or mt < oldest:
+                    oldest = mt
+            except OSError:
+                pass
+    return oldest
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Identify (and optionally delete) transient calibration states.")
+    parser.add_argument("--delete", action="store_true", help="Delete identified transient states after confirmation.")
+    args = parser.parse_args()
+
+    # Load reduction tally
+    if not os.path.isfile(TALLY_PATH):
+        print(f"ERROR: Reduction tally not found at {TALLY_PATH}")
+        print("Run build_reduction_tally.py first.")
+        sys.exit(1)
+
+    with open(TALLY_PATH, "r") as fh:
+        tally = json.load(fh)
+
+    reduced_states = set(tally.get("states", {}).keys())
+
+    # Enumerate all calibration states
+    all_states = sorted(
+        d for d in os.listdir(POWDER_HOME)
+        if os.path.isdir(os.path.join(POWDER_HOME, d)) and len(d) == 16
+    )
+
+    print(f"Calibration home: {CALIB_HOME}")
+    print(f"Total states:     {len(all_states)}")
+    print(f"Tally generated:  {tally.get('generated', '?')}")
+    print(f"Current cycle start: {CURRENT_CYCLE_START.date()}")
+    print()
+
+    transient = []
+    skipped_reasons = {}
+
+    for sid in all_states:
+        state_dir = os.path.join(POWDER_HOME, sid)
+        reasons_to_skip = []
+
+        # --- Criterion (a): only default v0 difcal, no normcal ---
+        difcal_index_path = os.path.join(state_dir, "lite", "diffraction", "CalibrationIndex.json")
+        normcal_index_path = os.path.join(state_dir, "lite", "normalization", "NormalizationIndex.json")
+
+        has_real_difcal = False
+        if os.path.isfile(difcal_index_path):
+            try:
+                with open(difcal_index_path, "r") as fh:
+                    idx = json.load(fh)
+                if len(idx) > 1:
+                    has_real_difcal = True
+            except Exception:
+                pass
+
+        has_normcal = os.path.isfile(normcal_index_path)
+
+        if has_real_difcal or has_normcal:
+            reasons_to_skip.append("has calibrations" if has_real_difcal else "has normcal")
+
+        # --- Criterion (b): never manually reduced ---
+        if sid in reduced_states:
+            state_info = tally["states"][sid]
+            manual_runs = state_info.get("manual_runs", state_info["total_runs"])
+            if manual_runs > 0:
+                reasons_to_skip.append(f"manually reduced ({manual_runs} manual runs)")
+            # else: only auto-reduced — does NOT protect the state
+
+        # --- Criterion (c): at least one cycle old ---
+        oldest_mt = oldest_file_mtime(state_dir)
+        if oldest_mt is not None:
+            created = datetime.fromtimestamp(oldest_mt)
+            if created >= CURRENT_CYCLE_START:
+                reasons_to_skip.append(f"created this cycle ({created.date()})")
+        else:
+            reasons_to_skip.append("cannot determine creation date")
+
+        if reasons_to_skip:
+            skipped_reasons[sid] = reasons_to_skip
+        else:
+            # Compute folder size for display
+            total_size = 0
+            for root, dirs, files in os.walk(state_dir):
+                for f in files:
+                    try:
+                        total_size += os.path.getsize(os.path.join(root, f))
+                    except OSError:
+                        pass
+            created_str = datetime.fromtimestamp(oldest_mt).strftime("%Y-%m-%d") if oldest_mt else "?"
+            auto_runs = 0
+            if sid in reduced_states:
+                auto_runs = tally["states"][sid].get("auto_runs", 0)
+            transient.append({
+                "stateID": sid,
+                "label": pull_state_label(sid),
+                "created": created_str,
+                "size_mb": total_size / (1024 * 1024),
+                "auto_runs": auto_runs,
+            })
+
+    # Report
+    print(f"States meeting ALL transient criteria: {len(transient)}")
+    print()
+
+    if transient:
+        total_mb = 0
+        for t in transient:
+            auto_note = f"  auto_runs={t['auto_runs']}" if t["auto_runs"] > 0 else ""
+            print(f"  {t['stateID']}  created={t['created']}  size={t['size_mb']:.1f} MB{auto_note}")
+            print(f"    {t['label']}")
+            total_mb += t["size_mb"]
+        print(f"\n  Total reclaimable: {total_mb:.1f} MB")
+    else:
+        print("  (none)")
+
+    # Show a few examples of states that were close but didn't qualify
+    print(f"\nStates that did NOT qualify ({len(skipped_reasons)}):")
+    # Show states that failed on only one criterion (closest to transient)
+    near_misses = [(sid, reasons) for sid, reasons in skipped_reasons.items() if len(reasons) == 1]
+    if near_misses:
+        print(f"  Near-misses (failed on one criterion only): {len(near_misses)}")
+        for sid, reasons in sorted(near_misses):
+            label = pull_state_label(sid)
+            print(f"    {sid}: {reasons[0]}")
+            print(f"      {label}")
+
+    # Delete if requested
+    if args.delete and transient:
+        print(f"\n{'='*60}")
+        print(f"About to DELETE {len(transient)} state folders.")
+        print(f"This will remove all calibration data for these states.")
+        answer = input("Proceed? [y/N]: ").strip().lower()
+        if answer == "y":
+            for t in transient:
+                path = os.path.join(POWDER_HOME, t["stateID"])
+                print(f"  Deleting {path} ...")
+                shutil.rmtree(path)
+                print(f"    deleted.")
+            print("Done.")
+        else:
+            print("Aborted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_legacy_states.py
+++ b/scripts/migrate_legacy_states.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+"""Migrate legacy calibration states to the new format by injecting indexEntry.
+
+For each legacy state (CalibrationRecord/Parameters missing 'indexEntry'):
+  1. Read the CalibrationIndex.json to get the index entry for each version.
+  2. Inject 'indexEntry' into CalibrationRecord.json and CalibrationParameters.json.
+  3. Also inject into nested 'calculationParameters.indexEntry' if present.
+
+Supports both difcal and normcal.  Backs up originals before modifying.
+
+Usage
+-----
+    python scripts/migrate_legacy_states.py                # dry run
+    python scripts/migrate_legacy_states.py --apply        # apply changes
+"""
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime
+
+
+CALIB_HOME = os.environ.get("CALIB_HOME", "/SNS/SNAP/shared/Calibration")
+POWDER_HOME = os.path.join(CALIB_HOME, "Powder")
+BACKUP_DIR = os.path.join(CALIB_HOME, "Backup")
+
+
+def find_legacy_versions(state_dir, cal_type):
+    """Return list of (version, index_entry, files_needing_migration) tuples."""
+
+    if cal_type == "difcal":
+        sub = "diffraction"
+        idx_name = "CalibrationIndex.json"
+        rec_name = "CalibrationRecord.json"
+        par_name = "CalibrationParameters.json"
+    else:
+        sub = "normalization"
+        idx_name = "NormalizationIndex.json"
+        rec_name = "NormalizationRecord.json"
+        par_name = "NormalizationParameters.json"
+
+    base = os.path.join(state_dir, "lite", sub)
+    idx_path = os.path.join(base, idx_name)
+
+    if not os.path.isfile(idx_path):
+        return []
+
+    with open(idx_path, "r") as fh:
+        index_entries = json.load(fh)
+
+    results = []
+    for ie in index_entries:
+        v = ie["version"]
+        folder = os.path.join(base, f"v_{str(v).zfill(4)}")
+        if not os.path.isdir(folder):
+            continue
+
+        files_to_fix = []
+        for fname in [rec_name, par_name]:
+            fp = os.path.join(folder, fname)
+            if not os.path.isfile(fp):
+                continue
+            with open(fp, "r") as fh:
+                data = json.load(fh)
+            if "indexEntry" not in data:
+                files_to_fix.append((fp, fname, data))
+
+        if files_to_fix:
+            results.append((v, ie, files_to_fix))
+
+    return results
+
+
+def migrate_file(fp, fname, data, index_entry, dry_run, backup_session):
+    """Inject indexEntry into a single JSON file.
+
+    Safety measures:
+      - Backs up the original before any modification.
+      - Writes to a temp file and renames (atomic on same filesystem).
+      - Re-reads the written file and verifies indexEntry round-trips.
+    """
+
+    # Add indexEntry at the top level
+    data["indexEntry"] = index_entry
+
+    # Also update nested calculationParameters if present (Records have this)
+    if "calculationParameters" in data and isinstance(data["calculationParameters"], dict):
+        data["calculationParameters"]["indexEntry"] = index_entry
+        # Also sync version if present
+        if "version" in data["calculationParameters"]:
+            data["calculationParameters"]["version"] = index_entry["version"]
+
+    if not dry_run:
+        # Backup original
+        rel = os.path.relpath(fp, CALIB_HOME)
+        bk_path = os.path.join(backup_session, rel)
+        os.makedirs(os.path.dirname(bk_path), exist_ok=True)
+        shutil.copy2(fp, bk_path)
+
+        # Atomic write: write to temp file in same directory, then rename
+        dir_name = os.path.dirname(fp)
+        fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp", prefix=".migrate_")
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(data, fh, indent=4)
+            os.replace(tmp_path, fp)  # atomic on same filesystem
+        except Exception:
+            # Clean up temp file on failure
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
+
+        # Post-write verification: re-read and confirm indexEntry matches
+        with open(fp, "r") as fh:
+            written = json.load(fh)
+        if written.get("indexEntry") != index_entry:
+            raise RuntimeError(
+                f"VERIFICATION FAILED for {fp}: "
+                f"written indexEntry does not match expected. "
+                f"Original backup at: {bk_path}"
+            )
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate legacy states to new index format.")
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default is dry run).")
+    parser.add_argument("--state", type=str, default=None,
+                        help="Migrate only this single stateID (for testing on one state first).")
+    args = parser.parse_args()
+
+    dry_run = not args.apply
+    prefix = "[DRY RUN] " if dry_run else ""
+
+    print(f"{prefix}Legacy state migration")
+    print(f"Calibration home: {CALIB_HOME}")
+    if args.state:
+        print(f"Filtering to single state: {args.state}")
+    print()
+
+    # Enumerate all states
+    all_states = sorted(
+        d for d in os.listdir(POWDER_HOME)
+        if os.path.isdir(os.path.join(POWDER_HOME, d)) and len(d) == 16
+    )
+
+    # Apply optional single-state filter
+    if args.state:
+        if args.state not in all_states:
+            print(f"ERROR: state {args.state} not found in {POWDER_HOME}")
+            return
+        all_states = [args.state]
+
+    # Find all legacy versions across all states
+    migration_plan = []  # (stateID, cal_type, version, index_entry, files_to_fix)
+
+    for sid in all_states:
+        state_dir = os.path.join(POWDER_HOME, sid)
+        for cal_type in ["difcal", "normcal"]:
+            legacy_versions = find_legacy_versions(state_dir, cal_type)
+            for v, ie, files in legacy_versions:
+                migration_plan.append((sid, cal_type, v, ie, files))
+
+    if not migration_plan:
+        print("No legacy versions found — nothing to migrate.")
+        return
+
+    # Summarise
+    states_affected = sorted(set(sid for sid, *_ in migration_plan))
+    total_files = sum(len(files) for _, _, _, _, files in migration_plan)
+
+    print(f"Found {len(migration_plan)} legacy version(s) across {len(states_affected)} state(s)")
+    print(f"Total files to update: {total_files}")
+    print()
+
+    for sid, cal_type, v, ie, files in migration_plan:
+        file_names = [fname for _, fname, _ in files]
+        print(f"  {prefix}{sid}  {cal_type} v{v}: {', '.join(file_names)}")
+        if dry_run:
+            # Show exactly what will be injected
+            print(f"    indexEntry to inject:")
+            for key, val in ie.items():
+                print(f"      {key}: {val}")
+
+    print()
+
+    if dry_run:
+        print("Run with --apply to perform the migration.")
+        if not args.state:
+            print("TIP: use --state <stateID> to test on a single state first.")
+        return
+
+    # Create backup session
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_session = os.path.join(BACKUP_DIR, f"migrate_legacy_{stamp}")
+    os.makedirs(backup_session, exist_ok=True)
+    print(f"Backup session: {backup_session}")
+    print()
+
+    # Apply
+    updated = 0
+    for sid, cal_type, v, ie, files in migration_plan:
+        for fp, fname, data in files:
+            migrate_file(fp, fname, data, ie, dry_run=False, backup_session=backup_session)
+            print(f"  Updated: {fp}")
+            print(f"    ✓ verified indexEntry round-trips correctly")
+            updated += 1
+
+    print(f"\n{updated} file(s) updated.")
+    print(f"Backups saved to: {backup_session}")
+
+    # Verify by re-scanning
+    print("\nPost-migration check:")
+    remaining = 0
+    for sid in states_affected:
+        state_dir = os.path.join(POWDER_HOME, sid)
+        for cal_type in ["difcal", "normcal"]:
+            leftovers = find_legacy_versions(state_dir, cal_type)
+            if leftovers:
+                remaining += len(leftovers)
+                for v, ie, files in leftovers:
+                    file_names = [fname for _, fname, _ in files]
+                    print(f"  STILL LEGACY: {sid} {cal_type} v{v}: {', '.join(file_names)}")
+
+    if remaining == 0:
+        print("  All migrated states now have indexEntry. ✓")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_fix_all.py
+++ b/scripts/run_fix_all.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Run fixIndex on all 16 failing states (for real, not dry-run).
+
+Groups:
+  - 1 appliesTo mismatch
+  - 3 orphaned folders
+  - 12 wrong-run-number (corrupt data files)
+"""
+
+import snapwrap.snapStateMgr as ssm
+
+# All 16 failing states from the post-legacy-delete scan
+failing_states = [
+    # Type 1: appliesTo mismatch
+    "04bd2c53f6bf6754",
+    # Type 2: orphaned folders (v_0001 with no index entry)
+    "22744cf05aaf2a8f",
+    "e1512a39893ebc99",
+    "fac358b3ffae68af",
+    # Type 3: wrong run number in data files (12 states)
+    "03c116b0df7506d9",
+    "0c66ac0318e26a13",
+    "0f78eb70a1c029b7",
+    "17fcca13ece67241",
+    "19b4f7d9436b3d40",
+    "6e421ac5d65ee355",
+    "702ba297516db7bf",
+    "7a68989468eb04f0",
+    "9ea6cc06fe835a1b",
+    "c073719d9101e8f2",
+    "d3e0c2862e8d3ad7",
+    "f4c4c8cd3e9fdfd4",
+]
+
+passed = []
+failed = []
+
+for i, sid in enumerate(failing_states, 1):
+    print(f"\n{'='*72}")
+    print(f"[{i}/{len(failing_states)}]  Fixing state: {sid}")
+    print(f"{'='*72}")
+
+    try:
+        result = ssm.fixIndex(stateID=sid, calType="difcal",
+                              dryRun=False, autoConfirm=True)
+        for a in result["actions"]:
+            print(a)
+
+        # Post-fix validation
+        print(f"\n--- Post-fix validation ---")
+        report = ssm.validateIndex(stateID=sid, calType="difcal")
+        ssm.printValidationReport(report)
+
+        if report["ok"]:
+            passed.append(sid)
+        else:
+            failed.append(sid)
+
+    except Exception as e:
+        print(f"  ERROR: {type(e).__name__}: {e}")
+        failed.append(sid)
+
+print(f"\n{'='*72}")
+print(f"COMPLETE")
+print(f"{'='*72}")
+print(f"  Fixed & validated: {len(passed)}/{len(failing_states)}")
+print(f"  Still failing:     {len(failed)}/{len(failing_states)}")
+if failed:
+    print(f"  Failed states: {failed}")

--- a/scripts/run_fix_dryrun.py
+++ b/scripts/run_fix_dryrun.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Test fixIndex in dry-run mode against known-corrupt states."""
+
+import snapwrap.snapStateMgr as ssm
+
+suspects = [
+    "e1512a39893ebc99",
+    "22744cf05aaf2a8f",
+    "0c66ac0318e26a13",
+    "9ea6cc06fe835a1b",
+    "fac358b3ffae68af",
+    "ca7c742288faf09c",
+    "04bd2c53f6bf6754",
+]
+
+for sid in suspects:
+    print("=" * 72)
+    print(f"DRY RUN: fixIndex for {sid} difcal")
+    print("=" * 72)
+    result = ssm.fixIndex(stateID=sid, calType="difcal", dryRun=True)
+    for a in result["actions"]:
+        print(a)
+    print()

--- a/scripts/run_fix_interactive.py
+++ b/scripts/run_fix_interactive.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Run fixIndex interactively against all suspect states (test calibration home)."""
+
+import snapwrap.snapStateMgr as ssm
+
+suspects = [
+    "e1512a39893ebc99",
+    "22744cf05aaf2a8f",
+    "0c66ac0318e26a13",
+    "9ea6cc06fe835a1b",
+    "fac358b3ffae68af",
+    "ca7c742288faf09c",
+    "04bd2c53f6bf6754",
+]
+
+for sid in suspects:
+    print("=" * 72)
+    print(f"fixIndex: {sid}  difcal")
+    print("=" * 72)
+    try:
+        result = ssm.fixIndex(stateID=sid, calType="difcal", dryRun=False, autoConfirm=False)
+        for a in result["actions"]:
+            print(a)
+    except Exception as e:
+        print(f"ERROR: {e}")
+    print()
+
+# Final validation pass
+print("\n" + "=" * 72)
+print("FINAL VALIDATION OF ALL STATES")
+print("=" * 72 + "\n")
+for sid in suspects:
+    for ct in ["difcal", "normcal"]:
+        try:
+            r = ssm.validateIndex(runNumber=None, stateID=sid, isLite=True, calType=ct)
+            ssm.printValidationReport(r)
+        except Exception as e:
+            print(f"ERROR validating {sid} {ct}: {e}")
+        print()

--- a/scripts/run_full_scan.py
+++ b/scripts/run_full_scan.py
@@ -3,6 +3,8 @@
 
 import snapwrap.snapStateMgr as ssm
 import os
+import re
+import json
 
 home = ssm.SNAPHome()
 powder = home.powder
@@ -16,8 +18,10 @@ states = ssm.availableStates()
 print(f"Total states found: {len(states)}")
 print("=" * 80)
 
-results = {"difcal": {"pass": [], "fail": [], "no_index": []},
-           "normcal": {"pass": [], "fail": [], "no_index": []}}
+results = {"difcal": {"pass": [], "fail": [], "no_index": [], "legacy": []},
+           "normcal": {"pass": [], "fail": [], "no_index": [], "legacy": []}}
+fail_details = {}  # (stateID, calType) -> list of issue strings
+fail_reports = {}  # (stateID, calType) -> raw validation report
 
 for i, sid in enumerate(sorted(states)):
     for ct in ["difcal", "normcal"]:
@@ -28,10 +32,30 @@ for i, sid in enumerate(sorted(states)):
                 has_no_index = any("not been normalized" in iss for iss in r.get("issues", []))
                 if has_no_index:
                     results[ct]["no_index"].append(sid)
+                    continue
+
+                # Check if any entries have legacy-format notes
+                has_legacy = False
+                for er in r.get("entries", []):
+                    if any("legacy" in iss.lower() for iss in er.get("issues", [])):
+                        has_legacy = True
+                        break
+                if has_legacy:
+                    results[ct]["legacy"].append(sid)
+                    ssm.printValidationReport(r)
+                    print()
                 else:
                     results[ct]["pass"].append(sid)
             else:
                 results[ct]["fail"].append(sid)
+                # Collect failure reasons for summary
+                details = list(r.get("issues", []))
+                for er in r.get("entries", []):
+                    for iss in er.get("issues", []):
+                        if "legacy" not in iss.lower():
+                            details.append(f"v{er.get('version','?')}: {iss}")
+                fail_details[(sid, ct)] = details
+                fail_reports[(sid, ct)] = r
                 ssm.printValidationReport(r)
                 print()
         except Exception as e:
@@ -49,19 +73,67 @@ for ct in ["difcal", "normcal"]:
     n_pass = len(results[ct]["pass"])
     n_fail = len(results[ct]["fail"])
     n_noidx = len(results[ct]["no_index"])
+    n_legacy = len(results[ct]["legacy"])
     pct_pass = 100.0 * n_pass / total if total else 0
     pct_fail = 100.0 * n_fail / total if total else 0
     pct_noidx = 100.0 * n_noidx / total if total else 0
+    pct_legacy = 100.0 * n_legacy / total if total else 0
 
     print(f"\n  {ct}:")
     print(f"    PASS:             {n_pass:4d}  ({pct_pass:5.1f}%)")
+    print(f"    PASS (legacy):    {n_legacy:4d}  ({pct_legacy:5.1f}%)  [older record format – missing indexEntry]")
     if ct == "normcal":
         print(f"    PASS (no index):  {n_noidx:4d}  ({pct_noidx:5.1f}%)")
     print(f"    FAIL:             {n_fail:4d}  ({pct_fail:5.1f}%)")
 
+    if results[ct]["legacy"]:
+        print(f"\n    Legacy-format states:")
+        for sid in results[ct]["legacy"]:
+            sd = ssm.pullStateDict(sid)
+            label = ssm.autoStateName(sd) if sd else "(unable to read state)"
+            print(f"      {sid}  {label}")
+
     if results[ct]["fail"]:
         print(f"\n    Failed states:")
         for sid in results[ct]["fail"]:
-            print(f"      {sid}")
+            sd = ssm.pullStateDict(sid)
+            label = ssm.autoStateName(sd) if sd else "(unable to read state)"
+            print(f"      {sid}  {label}")
+            for detail in fail_details.get((sid, ct), []):
+                print(f"        → {detail}")
+
+            # Check failing entries for propagation origin
+            rpt = fail_reports.get((sid, ct))
+            if rpt:
+                subFolder = "diffraction" if ct == "difcal" else "normalization"
+                jsonName = "CalibrationIndex.json" if ct == "difcal" else "NormalizationIndex.json"
+                idxPath = os.path.join(powder, sid, "lite", subFolder, jsonName)
+                try:
+                    with open(idxPath, "r") as fh:
+                        indexEntries = json.load(fh)
+                    # identify which versions failed
+                    failed_versions = set()
+                    for er in rpt.get("entries", []):
+                        if er.get("issues"):
+                            failed_versions.add(er.get("version"))
+                    # also check top-level issues for orphaned folders
+                    for iss in rpt.get("issues", []):
+                        m = re.search(r"Extra version folders.*?(\[.*?\])", iss)
+                        if m:
+                            for vf in re.findall(r"v_(\d+)", m.group(1)):
+                                failed_versions.add(int(vf))
+                    # scan entries for propagation comments
+                    prop_re = re.compile(r"\(copied from run:(\S+)\s+version:(\S+)\)")
+                    for ie in indexEntries:
+                        v = ie.get("version")
+                        comment = ie.get("comments", "")
+                        pm = prop_re.match(comment)
+                        if pm:
+                            donor_run = pm.group(1)
+                            donor_ver = pm.group(2)
+                            marker = " ← FAILING" if v in failed_versions else ""
+                            print(f"        ↳ v{v} propagated from run:{donor_run} ver:{donor_ver}{marker}")
+                except Exception:
+                    pass
 
 print()

--- a/scripts/run_full_scan.py
+++ b/scripts/run_full_scan.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Scan ALL states in the calibration home and report validation status."""
+
+import snapwrap.snapStateMgr as ssm
+import os
+
+home = ssm.SNAPHome()
+powder = home.powder
+
+print(f"Calibration home: {home.calib}")
+print(f"Powder home:      {powder}")
+print()
+
+# Get all state folders
+states = ssm.availableStates()
+print(f"Total states found: {len(states)}")
+print("=" * 80)
+
+results = {"difcal": {"pass": [], "fail": [], "no_index": []},
+           "normcal": {"pass": [], "fail": [], "no_index": []}}
+
+for i, sid in enumerate(sorted(states)):
+    for ct in ["difcal", "normcal"]:
+        try:
+            r = ssm.validateIndex(runNumber=None, stateID=sid, isLite=True, calType=ct)
+            if r["ok"]:
+                # Check if it's a "no index" pass (normcal only)
+                has_no_index = any("not been normalized" in iss for iss in r.get("issues", []))
+                if has_no_index:
+                    results[ct]["no_index"].append(sid)
+                else:
+                    results[ct]["pass"].append(sid)
+            else:
+                results[ct]["fail"].append(sid)
+                ssm.printValidationReport(r)
+                print()
+        except Exception as e:
+            results[ct]["fail"].append(sid)
+            print(f"ERROR  state={sid}  calType={ct}: {e}")
+            print()
+
+# Summary
+print("\n" + "=" * 80)
+print("SUMMARY")
+print("=" * 80)
+
+for ct in ["difcal", "normcal"]:
+    total = len(states)
+    n_pass = len(results[ct]["pass"])
+    n_fail = len(results[ct]["fail"])
+    n_noidx = len(results[ct]["no_index"])
+    pct_pass = 100.0 * n_pass / total if total else 0
+    pct_fail = 100.0 * n_fail / total if total else 0
+    pct_noidx = 100.0 * n_noidx / total if total else 0
+
+    print(f"\n  {ct}:")
+    print(f"    PASS:             {n_pass:4d}  ({pct_pass:5.1f}%)")
+    if ct == "normcal":
+        print(f"    PASS (no index):  {n_noidx:4d}  ({pct_noidx:5.1f}%)")
+    print(f"    FAIL:             {n_fail:4d}  ({pct_fail:5.1f}%)")
+
+    if results[ct]["fail"]:
+        print(f"\n    Failed states:")
+        for sid in results[ct]["fail"]:
+            print(f"      {sid}")
+
+print()

--- a/scripts/run_validate.py
+++ b/scripts/run_validate.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Quick smoke-test for validateIndex against suspect states."""
+
+import snapwrap.snapStateMgr as ssm
+
+suspects = [
+    "e1512a39893ebc99",
+    "22744cf05aaf2a8f",
+    "0c66ac0318e26a13",
+    "9ea6cc06fe835a1b",
+    "fac358b3ffae68af",
+    "ca7c742288faf09c",
+    "04bd2c53f6bf6754"
+]
+
+for sid in suspects:
+    for ct in ["difcal", "normcal"]:
+        try:
+            r = ssm.validateIndex(runNumber=None, stateID=sid, isLite=True, calType=ct)
+            ssm.printValidationReport(r)
+        except Exception as e:
+            print(f"ERROR validating {sid} {ct}: {e}")
+        print()

--- a/scripts/validate_all_test.py
+++ b/scripts/validate_all_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Validate all states in test calibration home after propagateDifcal."""
+import os
+import snapwrap.snapStateMgr as ssm
+
+home = ssm.SNAPHome()
+calibHome = home.calib
+powderHome = home.powder
+
+print(f"Calibration home: {calibHome}")
+print(f"Powder home:      {powderHome}")
+print()
+
+states = sorted([d for d in os.listdir(powderHome)
+                 if os.path.isdir(os.path.join(powderHome, d))
+                 and not d.startswith(".")])
+
+print(f"Found {len(states)} states\n")
+
+results = {"difcal": {"PASS": [], "FAIL": []}, "normcal": {"PASS": [], "FAIL": []}}
+
+for stateID in states:
+    for calType in ["difcal", "normcal"]:
+        # figure out a run number from the index
+        subdir = "diffraction" if calType == "difcal" else "normalization"
+        indexPath = os.path.join(powderHome, stateID, "lite", subdir, "CalibrationIndex.json")
+        if not os.path.exists(indexPath):
+            print(f"SKIP  state={stateID}  calType={calType}  (no index file)")
+            continue
+        import json
+        with open(indexPath) as f:
+            idx = json.load(f)
+        if not idx:
+            print(f"SKIP  state={stateID}  calType={calType}  (empty index)")
+            continue
+        runNumber = idx[0].get("runNumber", None)
+        if runNumber is None:
+            print(f"SKIP  state={stateID}  calType={calType}  (no runNumber in index)")
+            continue
+
+        report = ssm.validateIndex(runNumber=str(runNumber), stateID=stateID, calType=calType)
+        ssm.printValidationReport(report)
+        status = "PASS" if report["ok"] else "FAIL"
+        results[calType][status].append(stateID)
+
+print("\n" + "=" * 60)
+print("SUMMARY")
+print("=" * 60)
+for calType in ["difcal", "normcal"]:
+    total = len(results[calType]["PASS"]) + len(results[calType]["FAIL"])
+    if total == 0:
+        continue
+    nfail = len(results[calType]["FAIL"])
+    print(f"\n{calType}: {nfail}/{total} FAIL  ({100*nfail/total:.1f}%)")
+    if results[calType]["FAIL"]:
+        for s in results[calType]["FAIL"]:
+            print(f"  FAIL: {s}")

--- a/scripts/validate_e1512.py
+++ b/scripts/validate_e1512.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+"""Validate e1512a39893ebc99 after fix."""
+import snapwrap.snapStateMgr as ssm
+report = ssm.validateIndex(runNumber="68975", stateID="e1512a39893ebc99", calType="difcal")
+ssm.printValidationReport(report)

--- a/src/snapwrap/_version.py
+++ b/src/snapwrap/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.3.0.dev11"
+__version__ = "2.4.0.dev1"

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -926,6 +926,13 @@ def validateIndex(runNumber, stateID=None, isLite=True, calType="difcal", requir
             report["issues"].append(msg)
         report["ok"] = False
 
+    def _note(msg, entry_report=None):
+        """Record a non-fatal note (don't change overall ok status)."""
+        if entry_report is not None:
+            entry_report["issues"].append(msg)
+        else:
+            report["issues"].append(msg)
+
     # ------------------------------------------------------------------
     # Load allowed pgs names from groupingMap.json (case-insensitive)
     # ------------------------------------------------------------------
@@ -1095,8 +1102,18 @@ def validateIndex(runNumber, stateID=None, isLite=True, calType="difcal", requir
                     if not isinstance(rec, dict):
                         _flag(f"{rec_name} top-level value is not a dict", er)
                     else:
-                        if "version" not in rec or "indexEntry" not in rec:
+                        missing_version = "version" not in rec
+                        missing_index = "indexEntry" not in rec
+                        if missing_version and missing_index:
                             _flag(f"{rec_name} missing required keys 'version' and/or 'indexEntry'", er)
+                        elif missing_version:
+                            _flag(f"{rec_name} missing required key 'version'", er)
+                        elif missing_index:
+                            # Older SNAPRed-produced records (legacy format) may
+                            # omit the embedded indexEntry. Treat these as a
+                            # non-fatal note so they are tracked but don't make
+                            # the whole index fail the validation pass.
+                            _note(f"{rec_name} missing 'indexEntry' (legacy older record format) – treated as NOTE", er)
                         else:
                             if int(rec["version"]) != v:
                                 _flag(f"{rec_name}.version ({rec['version']}) != folder version {v}", er)
@@ -1149,8 +1166,14 @@ def validateIndex(runNumber, stateID=None, isLite=True, calType="difcal", requir
                     if not isinstance(rec, dict):
                         _flag(f"{rec_name} top-level value is not a dict", er)
                     else:
-                        if "version" not in rec or "indexEntry" not in rec:
+                        missing_version = "version" not in rec
+                        missing_index = "indexEntry" not in rec
+                        if missing_version and missing_index:
                             _flag(f"{rec_name} missing required keys 'version' and/or 'indexEntry'", er)
+                        elif missing_version:
+                            _flag(f"{rec_name} missing required key 'version'", er)
+                        elif missing_index:
+                            _note(f"{rec_name} missing 'indexEntry' (legacy older record format) – treated as NOTE", er)
                         else:
                             if int(rec["version"]) != v:
                                 _flag(f"{rec_name}.version ({rec['version']}) != folder version {v}", er)

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -734,8 +734,11 @@ def loadCalibrationRecord(runNum,isLite,version):
 
 def saveCalibrationRecord(calibrationRecord,indexEntry):
 
+    # Attach the indexEntry to the record; writeCalibrationRecord expects
+    # a single CalibrationRecord whose .indexEntry is already set.
+    calibrationRecord.indexEntry = indexEntry
     localDataService=LocalDataService()
-    localDataService.writeCalibrationRecord(calibrationRecord)#,indexEntry)
+    localDataService.writeCalibrationRecord(calibrationRecord)
 
     return
 
@@ -758,6 +761,7 @@ def frankenRecord(donorRun,
     recipientDefaultCR = loadCalibrationRecord(recipientRun,isLite,0)
     franken = copy.deepcopy(donorCR)
 
+    print("building franken record...")
     print("copied original calibration record")
 
     franken.version = recipientVersion
@@ -790,7 +794,7 @@ def frankenRecord(donorRun,
 
 
     if printRecord:
-        print("FRANKEN RECORD:")
+        print("\nFRANKEN RECORD:")
         print(franken.runNumber)
         print(franken.useLiteMode)
         print("version: ",franken.version)
@@ -842,3 +846,813 @@ def cycleForRun(runNumber):
     if cycle is None:
         print(f"cycleDates: no cycle found for run {runNumber}")
     return cycle
+
+def validateIndex(runNumber, stateID=None, isLite=True, calType="difcal", requireSameCycle=True):
+    """Validate a calibration/normalization index and its version subfolders.
+
+    Parameters mirror :func:`checkCalibrationStatus` so callers can pass a runNumber
+    (or ``None`` with an explicit *stateID*) and the function will locate the
+    appropriate index path.
+
+    Checks performed
+    ----------------
+    1. Each index entry has exactly the 7 required keys.
+    2. Versions start at 0 and increment by 1 with no gaps.
+    3. A ``v_####`` subfolder exists for every index entry (and no extras).
+    4. Version-folder contents match the expected file set (difcal / normcal).
+    5. Record JSON (``CalibrationRecord.json`` or ``NormalizationRecord.json``)
+       contains ``version`` and ``indexEntry`` that exactly match the index.
+    6. All JSON files inside version folders are syntactically valid.
+    7. The pixel-group string (pgs) inferred from filenames must correspond to
+       one of the focus-group names defined in ``groupingMap.json``.
+
+    Returns
+    -------
+    dict
+        ``ok`` : bool – ``True`` only when every check passes.
+        ``stateID`` : str
+        ``calType`` : str
+        ``isLite`` : bool
+        ``indexPath`` : str
+        ``issues`` : list[str] – top-level problems.
+        ``entries`` : list[dict] – per-index-entry results, each with
+        ``index``, ``version`` and ``issues`` keys.
+    """
+
+    # ------------------------------------------------------------------
+    # Normalise calType (same logic as checkCalibrationStatus)
+    # ------------------------------------------------------------------
+    if calType.lower() in ("nrmcal",):
+        calType = "normcal"
+    if calType.lower() == "difcal":
+        calType = "difcal"
+    if calType not in ("difcal", "normcal"):
+        raise ValueError("unsupported calibration type selected. Options are 'difcal' or 'normcal'")
+
+    if runNumber is None and stateID is None:
+        raise ValueError("Either runNumber or stateID must be provided")
+
+    if runNumber is not None:
+        [stateID, _] = stateDef(runNumber)
+
+    # ------------------------------------------------------------------
+    # Build paths (mirrors checkCalibrationStatus exactly)
+    # ------------------------------------------------------------------
+    home = SNAPHome()
+    powderHome = home.powder
+
+    subFolder = {"difcal": "diffraction", "normcal": "normalization"}
+    jsonName  = {"difcal": "CalibrationIndex.json", "normcal": "NormalizationIndex.json"}
+
+    liteStr = "lite" if isLite else "native"
+    calFolder = f"{powderHome}{stateID}/{liteStr}/{subFolder[calType]}/"
+    indexPath = f"{calFolder}{jsonName[calType]}"
+
+    report = {
+        "ok": True,
+        "stateID": stateID,
+        "calType": calType,
+        "isLite": isLite,
+        "indexPath": indexPath,
+        "issues": [],
+        "entries": [],
+    }
+
+    def _flag(msg, entry_report=None):
+        """Record an issue and set ok = False."""
+        if entry_report is not None:
+            entry_report["issues"].append(msg)
+        else:
+            report["issues"].append(msg)
+        report["ok"] = False
+
+    # ------------------------------------------------------------------
+    # Load allowed pgs names from groupingMap.json (case-insensitive)
+    # ------------------------------------------------------------------
+    grouping_map_path = os.path.join(powderHome, stateID, "groupingMap.json")
+    allowed_pgs = set()  # lowercase names; empty if file missing
+    if os.path.isfile(grouping_map_path):
+        try:
+            with open(grouping_map_path, "r") as fh:
+                gmap = json.load(fh)
+            key = "liteFocusGroups" if isLite else "nativeFocusGroups"
+            for entry in gmap.get(key, []):
+                allowed_pgs.add(entry["name"].lower())
+        except Exception as e:
+            _flag(f"Unable to parse groupingMap.json ({grouping_map_path}): {e}")
+    else:
+        _flag(f"groupingMap.json not found at {grouping_map_path} – pgs validation will be skipped")
+
+    # ------------------------------------------------------------------
+    # Basic existence checks
+    # ------------------------------------------------------------------
+    if not checkStateExists(stateID):
+        _flag(f"State {stateID} does not exist at {powderHome}")
+        return report
+
+    if not os.path.isfile(indexPath):
+        if calType == "normcal":
+            # A missing normalization index is valid – it simply means the
+            # state has not been normalized yet.
+            report["issues"].append("No normalization index exists (state has not been normalized – this is OK)")
+            return report
+        _flag(f"Index file not found: {indexPath}")
+        return report
+
+    # ------------------------------------------------------------------
+    # Load index JSON
+    # ------------------------------------------------------------------
+    try:
+        with open(indexPath, "r") as fh:
+            indexEntries = json.load(fh)
+    except Exception as e:
+        _flag(f"Failed to load index JSON {indexPath}: {type(e).__name__}: {e}")
+        return report
+
+    if not isinstance(indexEntries, list):
+        _flag(f"Index content is not a list in {indexPath}")
+        return report
+
+    # ------------------------------------------------------------------
+    # 1. Validate keys & collect versions
+    # ------------------------------------------------------------------
+    required_keys = {"version", "runNumber", "useLiteMode",
+                     "appliesTo", "comments", "author", "timestamp"}
+
+    versions = []
+    for i, ie in enumerate(indexEntries):
+        er = {"index": i, "version": ie.get("version"), "issues": []}
+
+        if set(ie.keys()) != required_keys:
+            missing_k = sorted(required_keys - set(ie.keys()))
+            extra_k   = sorted(set(ie.keys()) - required_keys)
+            parts = []
+            if missing_k:
+                parts.append(f"missing keys {missing_k}")
+            if extra_k:
+                parts.append(f"extra keys {extra_k}")
+            _flag(f"Entry {i}: key mismatch – {', '.join(parts)}", er)
+
+        if "version" in ie:
+            try:
+                versions.append(int(ie["version"]))
+            except Exception:
+                _flag(f"Entry {i}: 'version' is not an integer", er)
+        else:
+            _flag(f"Entry {i}: missing 'version' key", er)
+
+        report["entries"].append(er)
+
+    # ------------------------------------------------------------------
+    # 2. Version stride check
+    # ------------------------------------------------------------------
+    if versions:
+        sv = sorted(versions)
+        if sv[0] != 0:
+            _flag(f"Versions must start at 0; lowest version found: {sv[0]}")
+        for a, b in zip(sv, sv[1:]):
+            if b - a != 1:
+                _flag(f"Non-consecutive versions: ...{a}, {b}... (gap of {b - a})")
+
+    # ------------------------------------------------------------------
+    # 3. Folder ↔ index correspondence
+    # ------------------------------------------------------------------
+    expected_folders = {f"v_{str(v).zfill(4)}" for v in versions}
+    base_dir = os.path.dirname(indexPath)
+    try:
+        actual_items = os.listdir(base_dir)
+    except Exception as e:
+        _flag(f"Unable to list directory {base_dir}: {e}")
+        return report
+
+    actual_folders = {
+        n for n in actual_items
+        if os.path.isdir(os.path.join(base_dir, n)) and n.startswith("v_")
+    }
+    missing_folders = expected_folders - actual_folders
+    extra_folders   = actual_folders - expected_folders
+    if missing_folders:
+        _flag(f"Missing version folders: {sorted(missing_folders)}")
+    if extra_folders:
+        _flag(f"Extra version folders with no index entry: {sorted(extra_folders)}")
+
+    # ------------------------------------------------------------------
+    # Helper: validate pgs against groupingMap
+    # ------------------------------------------------------------------
+    def _check_pgs(pgs, entry_report):
+        """Warn if *pgs* is not a recognised focus-group name."""
+        if allowed_pgs and pgs.lower() not in allowed_pgs:
+            _flag(
+                f"pgs '{pgs}' is not a recognised focus-group name "
+                f"(allowed: {sorted(allowed_pgs)})",
+                entry_report,
+            )
+
+    # ------------------------------------------------------------------
+    # 4 – 6. Per-entry folder validation
+    # ------------------------------------------------------------------
+    for i, ie in enumerate(indexEntries):
+        er = report["entries"][i]
+        v = int(ie["version"]) if "version" in ie and isinstance(ie.get("version"), (int, float)) else -1
+        if v == -1:
+            # version already flagged above – skip folder checks
+            continue
+
+        run = str(ie.get("runNumber", "")).zfill(6)
+        folder_name = f"v_{str(v).zfill(4)}"
+        folder_path = os.path.join(base_dir, folder_name)
+
+        if not os.path.isdir(folder_path):
+            _flag(f"Version folder missing: {folder_name}", er)
+            continue
+
+        folder_contents = os.listdir(folder_path)
+
+        # 5. Validate every JSON file found in the folder
+        for fname in folder_contents:
+            if fname.endswith(".json"):
+                fp = os.path.join(folder_path, fname)
+                try:
+                    with open(fp, "r") as fh:
+                        json.load(fh)
+                except Exception as e:
+                    _flag(f"Invalid JSON in {fname}: {e}", er)
+
+        # ---- difcal ----
+        if calType == "difcal":
+            rec_name   = "CalibrationRecord.json"
+            param_name = "CalibrationParameters.json"
+            rec_fp   = os.path.join(folder_path, rec_name)
+            param_fp = os.path.join(folder_path, param_name)
+
+            # Record JSON
+            if not os.path.isfile(rec_fp):
+                _flag(f"Missing {rec_name}", er)
+            else:
+                try:
+                    with open(rec_fp, "r") as fh:
+                        rec = json.load(fh)
+                    if not isinstance(rec, dict):
+                        _flag(f"{rec_name} top-level value is not a dict", er)
+                    else:
+                        if "version" not in rec or "indexEntry" not in rec:
+                            _flag(f"{rec_name} missing required keys 'version' and/or 'indexEntry'", er)
+                        else:
+                            if int(rec["version"]) != v:
+                                _flag(f"{rec_name}.version ({rec['version']}) != folder version {v}", er)
+                            if rec["indexEntry"] != ie:
+                                _flag(f"{rec_name}.indexEntry does not exactly match the index entry", er)
+                except json.JSONDecodeError:
+                    pass  # already caught above
+                except Exception as e:
+                    _flag(f"Error reading {rec_name}: {e}", er)
+
+            # Parameters JSON
+            if not os.path.isfile(param_fp):
+                _flag(f"Missing {param_name}", er)
+
+            # Data files
+            if v == 0:
+                if not os.path.isfile(os.path.join(folder_path, "diffract_consts_default_v0.h5")):
+                    _flag("Missing diffract_consts_default_v0.h5 for version 0", er)
+            else:
+                # Infer pgs from dsp_<pgs>_<run>_v<ver>.nxs.h5
+                dsp_re = re.compile(rf"dsp_(.+)_{run}_v{str(v).zfill(4)}\.nxs\.h5")
+                dsp_hits = [m for m in (dsp_re.fullmatch(f) for f in folder_contents) if m]
+                if not dsp_hits:
+                    _flag(f"No dsp_<pgs>_{run}_v{str(v).zfill(4)}.nxs.h5 found – cannot determine pgs", er)
+                else:
+                    pgs = dsp_hits[0].group(1)
+                    _check_pgs(pgs, er)
+                    for ef in (
+                        f"dsp_{pgs}_{run}_v{str(v).zfill(4)}.nxs.h5",
+                        f"diffract_consts_{run}_v{str(v).zfill(4)}.h5",
+                        f"diagnostic_{pgs}_{run}_v{str(v).zfill(4)}.nxs.h5",
+                    ):
+                        if ef not in folder_contents:
+                            _flag(f"Missing expected file: {ef}", er)
+
+        # ---- normcal ----
+        else:
+            rec_name   = "NormalizationRecord.json"
+            param_name = "NormalizationParameters.json"
+            rec_fp   = os.path.join(folder_path, rec_name)
+            param_fp = os.path.join(folder_path, param_name)
+
+            # Record JSON
+            if not os.path.isfile(rec_fp):
+                _flag(f"Missing {rec_name}", er)
+            else:
+                try:
+                    with open(rec_fp, "r") as fh:
+                        rec = json.load(fh)
+                    if not isinstance(rec, dict):
+                        _flag(f"{rec_name} top-level value is not a dict", er)
+                    else:
+                        if "version" not in rec or "indexEntry" not in rec:
+                            _flag(f"{rec_name} missing required keys 'version' and/or 'indexEntry'", er)
+                        else:
+                            if int(rec["version"]) != v:
+                                _flag(f"{rec_name}.version ({rec['version']}) != folder version {v}", er)
+                            if rec["indexEntry"] != ie:
+                                _flag(f"{rec_name}.indexEntry does not exactly match the index entry", er)
+                except json.JSONDecodeError:
+                    pass  # already caught above
+                except Exception as e:
+                    _flag(f"Error reading {rec_name}: {e}", er)
+
+            # Parameters JSON
+            if not os.path.isfile(param_fp):
+                _flag(f"Missing {param_name}", er)
+
+            # Data files – infer pgs from dsp_<pgs>_<run>_fitted_van_corr_v<ver>.nxs
+            dsp_re = re.compile(rf"dsp_(.+)_{run}_fitted_van_corr_v{str(v).zfill(4)}\.nxs")
+            dsp_hits = [m for m in (dsp_re.fullmatch(f) for f in folder_contents) if m]
+            if not dsp_hits:
+                _flag(f"No dsp_<pgs>_{run}_fitted_van_corr_v{str(v).zfill(4)}.nxs found – cannot determine pgs", er)
+            else:
+                pgs = dsp_hits[0].group(1)
+                _check_pgs(pgs, er)
+                for ef in (
+                    f"tof_unfoc_{run}_raw_van_corr_v{str(v).zfill(4)}.nxs",
+                    f"tof_{pgs}_s+f-vanadium_{run}_v{str(v).zfill(4)}.nxs",
+                    f"dsp_{pgs}_{run}_fitted_van_corr_v{str(v).zfill(4)}.nxs",
+                ):
+                    if ef not in folder_contents:
+                        _flag(f"Missing expected file: {ef}", er)
+
+    return report
+
+
+def printValidationReport(report):
+    """Pretty-print a report dict returned by :func:`validateIndex`."""
+
+    header = (
+        f"{'PASS' if report['ok'] else 'FAIL'}  "
+        f"state={report['stateID']}  calType={report['calType']}  "
+        f"lite={report['isLite']}"
+    )
+    print(header)
+    print(f"  index: {report['indexPath']}")
+
+    if report["issues"]:
+        label = "Issues:" if not report["ok"] else "Notes:"
+        print(f"  {label}")
+        marker = "✗" if not report["ok"] else "ℹ"
+        for issue in report["issues"]:
+            print(f"    {marker} {issue}")
+
+    for er in report.get("entries", []):
+        if er["issues"]:
+            print(f"  Entry {er['index']} (version {er['version']}):")
+            for issue in er["issues"]:
+                print(f"    ✗ {issue}")
+
+    if report["ok"]:
+        n = len(report.get("entries", []))
+        print(f"  All {n} entries validated successfully.")
+
+    return
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 repair utilities
+# ---------------------------------------------------------------------------
+
+def _backup_dir():
+    """Return (and create) the central backup directory under the calibration home."""
+    home = SNAPHome()
+    bk = os.path.join(home.calib, "Backup")
+    os.makedirs(bk, exist_ok=True)
+    return bk
+
+
+def _session_backup_dir(stateID, calType):
+    """Return (and create) a timestamped per-session backup folder.
+
+    Layout: ``{calib}/Backup/fix_{stateID}_{calType}_{YYYYMMDD_HHMMSS}/``
+    """
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    d = os.path.join(_backup_dir(), f"fix_{stateID}_{calType}_{stamp}")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _folder_stat_summary(folder_path):
+    """Return a human-readable summary of a folder's timestamps and contents."""
+    lines = []
+    try:
+        st = os.stat(folder_path)
+        lines.append(f"  path:  {folder_path}")
+        lines.append(f"  ctime: {datetime.fromtimestamp(st.st_ctime).isoformat()}")
+        lines.append(f"  mtime: {datetime.fromtimestamp(st.st_mtime).isoformat()}")
+        contents = sorted(os.listdir(folder_path))
+        lines.append(f"  contents ({len(contents)} items):")
+        for c in contents:
+            fp = os.path.join(folder_path, c)
+            sz = os.path.getsize(fp) if os.path.isfile(fp) else 0
+            lines.append(f"    {c}  ({sz} bytes)" if os.path.isfile(fp) else f"    {c}/")
+    except Exception as e:
+        lines.append(f"  (unable to stat: {e})")
+    return "\n".join(lines)
+
+
+def fixIndex(runNumber=None, stateID=None, isLite=True, calType="difcal",
+             dryRun=False, autoConfirm=False):
+    """Repair a calibration/normalization index so it passes :func:`validateIndex`.
+
+    This function performs the following repairs **in order**:
+
+    1. **Sync record ``indexEntry``** — for every version folder whose
+       ``CalibrationRecord.json`` (or ``NormalizationRecord.json``)
+       ``indexEntry`` or ``version`` disagrees with the calibration index,
+       overwrite the record to match the index.  Also updates the nested
+       ``calculationParameters.indexEntry`` and
+       ``calculationParameters.version`` copies.
+
+    2. **Remove orphaned folders** — version folders on disk that have no
+       matching index entry are deleted (after logging their contents and
+       timestamps).
+
+    3. **Remove orphaned index entries** — index entries whose version
+       folder is missing are removed from the index.
+
+    4. **Re-version** — after removals the remaining entries are
+       re-numbered starting at 0 with stride 1.  Folders are renamed and
+       all embedded version references (record JSON files, data-file
+       names) are updated accordingly.
+
+    A detailed log of every action is written to a session-specific
+    backup folder under ``{calibration_home}/Backup/``.
+
+    Parameters
+    ----------
+    runNumber, stateID, isLite, calType
+        Same semantics as :func:`validateIndex`.
+    dryRun : bool
+        If ``True``, report what *would* be done without modifying anything.
+    autoConfirm : bool
+        If ``True``, skip the interactive confirmation prompt.
+
+    Returns
+    -------
+    dict
+        ``actions`` : list[str] – description of each action taken (or planned).
+        ``logFile`` : str – path to the saved log file (``None`` in dry-run mode).
+        ``backupDir`` : str – path to the backup session folder.
+    """
+
+    # ------------------------------------------------------------------
+    # Resolve paths (identical to validateIndex)
+    # ------------------------------------------------------------------
+    if calType.lower() in ("nrmcal",):
+        calType = "normcal"
+    if calType.lower() == "difcal":
+        calType = "difcal"
+    if calType not in ("difcal", "normcal"):
+        raise ValueError("calType must be 'difcal' or 'normcal'")
+    if runNumber is None and stateID is None:
+        raise ValueError("Either runNumber or stateID must be provided")
+    if runNumber is not None:
+        [stateID, _] = stateDef(runNumber)
+
+    home = SNAPHome()
+    powderHome = home.powder
+    subFolder = {"difcal": "diffraction", "normcal": "normalization"}
+    jsonName  = {"difcal": "CalibrationIndex.json", "normcal": "NormalizationIndex.json"}
+    recName   = {"difcal": "CalibrationRecord.json", "normcal": "NormalizationRecord.json"}
+    liteStr   = "lite" if isLite else "native"
+    base_dir  = f"{powderHome}{stateID}/{liteStr}/{subFolder[calType]}"
+    indexPath = os.path.join(base_dir, jsonName[calType])
+
+    actions = []     # human-readable log lines
+    prefix = "[DRY RUN] " if dryRun else ""
+
+    def log(msg):
+        actions.append(f"{prefix}{msg}")
+
+    # ------------------------------------------------------------------
+    # Pre-flight: run validateIndex to see current state
+    # ------------------------------------------------------------------
+    pre_report = validateIndex(runNumber=runNumber, stateID=stateID,
+                               isLite=isLite, calType=calType)
+    if pre_report["ok"]:
+        log("Index already valid – nothing to fix.")
+        return {"actions": actions, "logFile": None, "backupDir": None}
+
+    # ------------------------------------------------------------------
+    # Load index
+    # ------------------------------------------------------------------
+    if not os.path.isfile(indexPath):
+        log(f"ERROR: Index file not found: {indexPath} – cannot repair.")
+        return {"actions": actions, "logFile": None, "backupDir": None}
+
+    with open(indexPath, "r") as fh:
+        indexEntries = json.load(fh)
+
+    # ------------------------------------------------------------------
+    # Create backup session
+    # ------------------------------------------------------------------
+    sessionDir = _session_backup_dir(stateID, calType)
+    log(f"Backup session: {sessionDir}")
+
+    # Back up the original index
+    bkIndex = os.path.join(sessionDir, jsonName[calType])
+    if not dryRun:
+        shutil.copy2(indexPath, bkIndex)
+    log(f"Backed up original index → {bkIndex}")
+
+    # ------------------------------------------------------------------
+    # Discover orphaned folders and orphaned index entries
+    # ------------------------------------------------------------------
+    indexed_versions = {}  # version -> index entry
+    for ie in indexEntries:
+        indexed_versions[int(ie["version"])] = ie
+
+    actual_folders = {
+        n for n in os.listdir(base_dir)
+        if os.path.isdir(os.path.join(base_dir, n)) and n.startswith("v_")
+    }
+    actual_versions = {}
+    for fn in actual_folders:
+        try:
+            actual_versions[int(fn.split("_")[1])] = fn
+        except (ValueError, IndexError):
+            pass
+
+    orphaned_folders = sorted(set(actual_versions.keys()) - set(indexed_versions.keys()))
+    orphaned_entries = sorted(set(indexed_versions.keys()) - set(actual_versions.keys()))
+
+    # ------------------------------------------------------------------
+    # Detect corrupt entries: folder exists but data files are wrong
+    # ------------------------------------------------------------------
+    # Use the per-entry issues from the validation report to identify
+    # entries whose version folder is present but whose contents are
+    # irrecoverably inconsistent (e.g. data files have the wrong run
+    # number).  These are treated the same as orphaned entries + orphaned
+    # folders: both the folder and the index entry are removed.
+    corrupt_versions = []
+    for er in pre_report.get("entries", []):
+        v = er.get("version")
+        if v is None or int(v) in set(orphaned_folders) | set(orphaned_entries):
+            continue
+        # Look for issues that indicate the folder data is unusable
+        for issue in er.get("issues", []):
+            if any(marker in issue for marker in [
+                "cannot determine pgs",
+                "Missing expected file:",
+                "Missing CalibrationRecord.json",
+                "Missing NormalizationRecord.json",
+                "Missing CalibrationParameters.json",
+                "Missing NormalizationParameters.json",
+            ]):
+                corrupt_versions.append(int(v))
+                break
+
+    # ------------------------------------------------------------------
+    # Build action plan summary for user confirmation
+    # ------------------------------------------------------------------
+    plan_lines = []
+
+    # Step 1: record syncs (only for entries not already marked corrupt)
+    corrupt_set = set(corrupt_versions)
+    sync_targets = []
+    for ie in indexEntries:
+        v = int(ie["version"])
+        if v in corrupt_set:
+            continue  # will be deleted, no point syncing
+        folder_path = os.path.join(base_dir, f"v_{str(v).zfill(4)}")
+        rec_fp = os.path.join(folder_path, recName[calType])
+        if not os.path.isfile(rec_fp):
+            continue
+        try:
+            with open(rec_fp, "r") as fh:
+                rec = json.load(fh)
+            needs_sync = False
+            if rec.get("indexEntry") != ie:
+                needs_sync = True
+            if int(rec.get("version", -1)) != v:
+                needs_sync = True
+            if needs_sync:
+                sync_targets.append((v, ie, rec_fp))
+        except Exception:
+            pass
+
+    if sync_targets:
+        plan_lines.append(f"  Sync indexEntry in {len(sync_targets)} record(s): versions {[t[0] for t in sync_targets]}")
+
+    if corrupt_versions:
+        for v in corrupt_versions:
+            fp = os.path.join(base_dir, f"v_{str(v).zfill(4)}")
+            ie = indexed_versions[v]
+            plan_lines.append(f"  DELETE corrupt entry v={v} (run {ie.get('runNumber')}) – folder & index entry: {fp}")
+
+    if orphaned_folders:
+        for v in orphaned_folders:
+            fp = os.path.join(base_dir, actual_versions[v])
+            plan_lines.append(f"  DELETE orphaned folder (no index entry): {fp}")
+
+    if orphaned_entries:
+        plan_lines.append(f"  Remove {len(orphaned_entries)} orphaned index entries (no folder): versions {orphaned_entries}")
+
+    # Check if re-versioning needed
+    all_removed = set(orphaned_entries) | corrupt_set
+    surviving = sorted(set(indexed_versions.keys()) - all_removed)
+    needs_reversion = surviving != list(range(len(surviving)))
+
+    if needs_reversion:
+        plan_lines.append(f"  Re-version {len(surviving)} entries: {surviving} → {list(range(len(surviving)))}")
+
+    if not plan_lines:
+        log("No actionable repairs identified (issues may require manual intervention).")
+        return {"actions": actions, "logFile": None, "backupDir": sessionDir}
+
+    # ------------------------------------------------------------------
+    # Confirm with user
+    # ------------------------------------------------------------------
+    print(f"\n{'[DRY RUN] ' if dryRun else ''}Repair plan for state={stateID}  calType={calType}  lite={isLite}:")
+    for line in plan_lines:
+        print(line)
+    print()
+
+    if not dryRun and not autoConfirm:
+        answer = input("Proceed with repairs? [y/N]: ").strip().lower()
+        if answer != "y":
+            log("User declined repairs.")
+            print("Aborted.")
+            return {"actions": actions, "logFile": None, "backupDir": sessionDir}
+
+    # ------------------------------------------------------------------
+    # Step 1: Sync record indexEntry to match index
+    # ------------------------------------------------------------------
+    for v, ie, rec_fp in sync_targets:
+        log(f"Syncing {recName[calType]} in v_{str(v).zfill(4)} to match index entry")
+        if not dryRun:
+            # Back up the original record
+            rec_bk = os.path.join(sessionDir, f"v_{str(v).zfill(4)}_{recName[calType]}")
+            shutil.copy2(rec_fp, rec_bk)
+
+            with open(rec_fp, "r") as fh:
+                rec = json.load(fh)
+
+            rec["version"] = int(ie["version"])
+            rec["indexEntry"] = ie
+            if "calculationParameters" in rec and isinstance(rec["calculationParameters"], dict):
+                rec["calculationParameters"]["indexEntry"] = ie
+                rec["calculationParameters"]["version"] = int(ie["version"])
+
+            with open(rec_fp, "w") as fh:
+                json.dump(rec, fh, indent=4)
+
+            log(f"  backed up original → {rec_bk}")
+            log(f"  updated {rec_fp}")
+
+    # ------------------------------------------------------------------
+    # Step 2: Delete orphaned folders (no index entry)
+    # ------------------------------------------------------------------
+    for v in orphaned_folders:
+        folder_path = os.path.join(base_dir, actual_versions[v])
+        log(f"Deleting orphaned folder: {folder_path}")
+        log(_folder_stat_summary(folder_path))
+        if not dryRun:
+            shutil.rmtree(folder_path)
+            log(f"  deleted.")
+
+    # ------------------------------------------------------------------
+    # Step 3: Delete corrupt entries (folder + index entry)
+    # ------------------------------------------------------------------
+    for v in corrupt_versions:
+        folder_path = os.path.join(base_dir, f"v_{str(v).zfill(4)}")
+        ie = indexed_versions[v]
+        log(f"Deleting corrupt entry v={v} (run {ie.get('runNumber')})")
+        log(_folder_stat_summary(folder_path))
+        if not dryRun:
+            if os.path.isdir(folder_path):
+                shutil.rmtree(folder_path)
+                log(f"  deleted folder.")
+            indexEntries = [e for e in indexEntries if int(e["version"]) != v]
+            log(f"  removed index entry for version {v}.")
+
+    # ------------------------------------------------------------------
+    # Step 4: Remove orphaned index entries (no folder)
+    # ------------------------------------------------------------------
+    if orphaned_entries:
+        log(f"Removing orphaned index entries for versions: {orphaned_entries}")
+        if not dryRun:
+            remove_set = set(orphaned_entries)
+            indexEntries = [ie for ie in indexEntries if int(ie["version"]) not in remove_set]
+
+    # ------------------------------------------------------------------
+    # Step 5: Re-version remaining entries and folders
+    # ------------------------------------------------------------------
+    # Sort by current version
+    indexEntries.sort(key=lambda ie: int(ie["version"]))
+
+    old_to_new = {}
+    for new_v, ie in enumerate(indexEntries):
+        old_v = int(ie["version"])
+        if old_v != new_v:
+            old_to_new[old_v] = new_v
+
+    if old_to_new:
+        log(f"Re-versioning: {old_to_new}")
+
+        if not dryRun:
+            # Rename folders: use a temporary name first to avoid collisions
+            # e.g. v_0003 -> v_0003_tmp -> v_0001
+            temp_names = {}
+            for old_v, new_v in old_to_new.items():
+                old_folder = os.path.join(base_dir, f"v_{str(old_v).zfill(4)}")
+                tmp_folder = os.path.join(base_dir, f"v_{str(old_v).zfill(4)}_tmp")
+                if os.path.isdir(old_folder):
+                    os.rename(old_folder, tmp_folder)
+                    temp_names[new_v] = tmp_folder
+                    log(f"  renamed v_{str(old_v).zfill(4)} → v_{str(old_v).zfill(4)}_tmp")
+
+            for new_v, tmp_folder in temp_names.items():
+                new_folder = os.path.join(base_dir, f"v_{str(new_v).zfill(4)}")
+                os.rename(tmp_folder, new_folder)
+                log(f"  renamed {os.path.basename(tmp_folder)} → v_{str(new_v).zfill(4)}")
+
+        # Update version in index entries
+        for new_v, ie in enumerate(indexEntries):
+            old_v = int(ie["version"])
+            if old_v != new_v:
+                log(f"  index entry version {old_v} → {new_v}")
+            ie["version"] = new_v
+
+        # Update records inside re-versioned folders
+        if not dryRun:
+            for new_v, ie in enumerate(indexEntries):
+                folder_path = os.path.join(base_dir, f"v_{str(new_v).zfill(4)}")
+                rec_fp = os.path.join(folder_path, recName[calType])
+                if os.path.isfile(rec_fp):
+                    try:
+                        with open(rec_fp, "r") as fh:
+                            rec = json.load(fh)
+                        rec["version"] = new_v
+                        rec["indexEntry"] = ie
+                        if "calculationParameters" in rec and isinstance(rec["calculationParameters"], dict):
+                            rec["calculationParameters"]["indexEntry"] = ie
+                            rec["calculationParameters"]["version"] = new_v
+                        with open(rec_fp, "w") as fh:
+                            json.dump(rec, fh, indent=4)
+                        log(f"  updated record in v_{str(new_v).zfill(4)}")
+                    except Exception as e:
+                        log(f"  WARNING: could not update record in v_{str(new_v).zfill(4)}: {e}")
+
+            # Rename data files inside re-versioned folders
+            for old_v, new_v in old_to_new.items():
+                folder_path = os.path.join(base_dir, f"v_{str(new_v).zfill(4)}")
+                if not os.path.isdir(folder_path):
+                    continue
+                for fname in os.listdir(folder_path):
+                    old_tag = f"_v{str(old_v).zfill(4)}"
+                    new_tag = f"_v{str(new_v).zfill(4)}"
+                    if old_tag in fname:
+                        new_fname = fname.replace(old_tag, new_tag)
+                        os.rename(os.path.join(folder_path, fname),
+                                  os.path.join(folder_path, new_fname))
+                        log(f"  renamed {fname} → {new_fname}")
+
+    # ------------------------------------------------------------------
+    # Write updated index
+    # ------------------------------------------------------------------
+    if not dryRun:
+        with open(indexPath, "w") as fh:
+            json.dump(indexEntries, fh, indent=4)
+        log(f"Saved updated index: {indexPath}")
+
+    # ------------------------------------------------------------------
+    # Post-flight validation
+    # ------------------------------------------------------------------
+    post_report = validateIndex(runNumber=None, stateID=stateID,
+                                isLite=isLite, calType=calType)
+    if post_report["ok"]:
+        log("Post-repair validation: PASS ✓")
+    else:
+        log("Post-repair validation: FAIL — some issues remain:")
+        for issue in post_report["issues"]:
+            log(f"  {issue}")
+        for er in post_report.get("entries", []):
+            for issue in er["issues"]:
+                log(f"  Entry {er['index']}: {issue}")
+
+    # ------------------------------------------------------------------
+    # Write log file
+    # ------------------------------------------------------------------
+    logPath = None
+    if not dryRun:
+        logPath = os.path.join(sessionDir, "fix_log.txt")
+        with open(logPath, "w") as fh:
+            fh.write(f"fixIndex log  {datetime.now().isoformat()}\n")
+            fh.write(f"stateID: {stateID}  calType: {calType}  isLite: {isLite}\n")
+            fh.write(f"indexPath: {indexPath}\n")
+            fh.write("=" * 72 + "\n")
+            for line in actions:
+                fh.write(line + "\n")
+        log(f"Log written to {logPath}")
+    else:
+        log("(dry run – no files modified)")
+
+    return {"actions": actions, "logFile": logPath, "backupDir": sessionDir}

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -631,10 +631,15 @@ def copyDifcal(donor,recipient,propagate=False): # donor and recipient are Calib
     print(f"\nDONOR STATE: {stateDef(donorRun)[0]} with {donor['numberCalibrations']} total calibrations")
     print(f"Most recent valid calibration is version {donorCal['version']} this will be copied:")
 
+    # Determine new version from the highest existing version number in the
+    # index (NOT from the timestamp-sorted "latest" entry, because propagated
+    # calibrations inherit the donor's timestamp which may predate the v0
+    # creation timestamp).
+    maxExistingVersion = max(entry["version"] for entry in recipient["calibIndexList"])
+    newVersion = maxExistingVersion + 1
 
     print(f"\nRECIPIENT STATE: {stateDef(recipientRun)[0]} with {recipient['numberCalibrations']} total calibrations")
-    newVersion = recipientCal['version']+1
-    print(f"Most recent calibration is version {recipientCal['version']} this will be updated to version {newVersion}")
+    print(f"Highest existing version is {maxExistingVersion}, this will be updated to version {newVersion}")
 
     newIE = IndexEntry(version=newVersion, #one more than most recent
         runNumber=recipientCal["runNumber"],

--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -292,10 +292,32 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal",
         
         return calStatus
 
-    #load calibration index     
-    f = open(indexPath)
-    calIndexList = json.load(f) # a list of all calibrations
-    f.close()
+    #load calibration index
+    try:
+        with open(indexPath, 'r') as fh:
+            calIndexList = json.load(fh)  # a list of all calibrations
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Failed to parse JSON in calibration index at {indexPath}: {e}")
+        calStatus["stateIsCalibrated"] = False
+        calStatus["runIsCalibrated"] = False
+        calStatus["numberCalibrations"] = 0
+        calStatus["latestCalibrationDate"] = "never"
+        calStatus["latestCalibrationDict"] = {}
+        calStatus["latestValidCalibrationDate"] = "never"
+        calStatus["latestValidCalibrationDict"] = {}
+        calStatus["statusDetail"] = f"calibration index exists but contains invalid JSON: {indexPath}"
+        return calStatus
+    except Exception as e:
+        print(f"ERROR: Unexpected error reading calibration index at {indexPath}: {type(e).__name__}: {e}")
+        calStatus["stateIsCalibrated"] = False
+        calStatus["runIsCalibrated"] = False
+        calStatus["numberCalibrations"] = 0
+        calStatus["latestCalibrationDate"] = "never"
+        calStatus["latestCalibrationDict"] = {}
+        calStatus["latestValidCalibrationDate"] = "never"
+        calStatus["latestValidCalibrationDict"] = {}
+        calStatus["statusDetail"] = f"unexpected error reading calibration index: {indexPath}"
+        return calStatus
 
     ## case: difcal requested, state exists, but no difcal exists (only default)
     if len(calIndexList) == 1 and calType == "difcal":
@@ -326,7 +348,7 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal",
     tsTypes = {type(d["timestamp"]) for d in calIndexList}
 
     if len(tsTypes) != 1:
-        raise TypeError(f"Inconsistent timestamp types found in calibration index: {types}")
+        raise TypeError(f"Inconsistent timestamp types found in calibration index: {tsTypes}")
 
     t = tsTypes.pop()
     if t in (int, float):
@@ -494,13 +516,23 @@ def pullStateDict(stateIDString):
     # the plan is to create a script to  
 
     stateSeedDir = f"{Config['instrument.calibration.home']}/Powder/{stateIDString}/lite/diffraction/v_0000/"
-    stateParamsJson = stateSeedDir + "/CalibrationParameters.json"
+    stateParamsPath = os.path.join(stateSeedDir, "CalibrationParameters.json")
 
-    f = open(stateParamsJson)
-    stateParamsJson = json.load(f)
-    f.close()
+    # Read calibration parameters with robust error messages for common failure modes
+    try:
+        with open(stateParamsPath, 'r') as fh:
+            stateParams = json.load(fh)
+    except FileNotFoundError:
+        print(f"ERROR: CalibrationParameters.json not found at: {stateParamsPath}")
+        return {}
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Failed to parse JSON in CalibrationParameters.json at {stateParamsPath}: {e}")
+        return {}
+    except Exception as e:
+        print(f"ERROR: Unexpected error reading {stateParamsPath}: {type(e).__name__}: {e}")
+        return {}
 
-    detectorState = stateParamsJson["instrumentState"]["detectorState"]
+    detectorState = stateParams["instrumentState"]["detectorState"]
     if "PVs" in detectorState.keys():
         dict = detectorState["PVs"]
 

--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -428,8 +428,31 @@ def indexStates(isLite=True):
         nDifcal = difcal['numberCalibrations']
 
         if difcal['latestCalibrationDate'] != "never":
-            latestDifcalRun = difcal['latestCalibrationDict']['runNumber']
-            latestDifcalCycle = ssm.cycleForRun(latestDifcalRun) or ""
+            # We want the most recent *cycle* that has a calibration, not the most
+            # recent calibration by timestamp (which could be a re-calibration for
+            # an older cycle).  Iterate all index entries, resolve each to its
+            # effective run number (accounting for propagated calibrations whose
+            # true donor run is embedded in the comments field), map to cycle, and
+            # pick the latest.
+            import re
+            bestCycle = ""
+            bestRun = ""
+            for entry in difcal['calibIndexList']:
+                # skip the default geometric entry (version 0)
+                if entry.get('version', -1) == 0:
+                    continue
+                comment = entry.get('comments', '')
+                propagated = re.match(r"\(copied from run:(\S+)\s+version:", comment)
+                if propagated:
+                    effectiveRun = propagated.group(1)
+                else:
+                    effectiveRun = entry['runNumber']
+                cycle = ssm.cycleForRun(effectiveRun) or ""
+                if cycle > bestCycle:
+                    bestCycle = cycle
+                    bestRun = effectiveRun
+            latestDifcalRun = bestRun
+            latestDifcalCycle = bestCycle
         else:
             latestDifcalRun = ""
             latestDifcalCycle = ""


### PR DESCRIPTION
# Short description of the changes:

copyDifcal bugfix: Version increment now uses max(version) from the index list instead of the timestamp-sorted "latest" entry
validateIndex/fixIndex: Legacy record handling + repair of 16 corrupt states
6 new diagnostic scripts for scanning, tallying, and repairing calibration states
Version bump to 2.4.0.dev1