### PR TITLE
fixed bug causing failure when qsp=true and simultaneously continueNo…

### DIFF
--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -2134,7 +2134,7 @@ def reduce(runNumber,
 
     if qsp:
         # post reduction, need to convert d-space reduced data to Q-space
-        
+
         outputWSList_Q = [] #reset to hold q-space names
         if outputWSList is not None:
             for dspName in outputWSList:
@@ -2148,8 +2148,13 @@ def reduce(runNumber,
                             OutputWorkspace= qspName,
                             Delta = rebPrm) #ragged is needed as Qmin/max vary
                 
-                #lastly, downsample d-space data back to original request
-                handle = io.redObject(dspName)
+                # lastly, downsample d-space data back to original request. have to handle possiblity
+                # that we are in diagnostic mode.
+                if any("diagnostic" in s for s in outputWSList):
+                    handle = io.redObject(dspName, requiredPrefix='diagnostic')
+                else:
+                    handle = io.redObject(dspName)
+                
                 restoreDBins(handle,originalIngredients)
 
                 outputWSList_Q.append(qspName)


### PR DESCRIPTION
qsp=true parameter of `reduce` assumes that reduced data will be in a workspace with prefix `reduced`, but this is not the case in diaognostic reduction where the workspace prefix is `diagnostic`. Added a check for this

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
