### PR TITLE
fix: use effective (donor) run for cycleID annotation of propagated c…

### DIFF
--- a/src/snapwrap/snapStateMgr.py
+++ b/src/snapwrap/snapStateMgr.py
@@ -362,10 +362,20 @@ def checkCalibrationStatus(runNumber,stateID=None, isLite=True,calType="difcal",
                       reverse=True
                       )
 
-    # Annotate every index entry with its cycleID (looked up from runNumber)
+    # Annotate every index entry with its cycleID.
+    # For propagated calibrations the runNumber field still contains the
+    # *recipient* state's original run, not the donor run that was actually
+    # used to produce the calibration.  The donor run is recorded in the
+    # comments field as "(copied from run:<run> version:<ver>)".  We must
+    # use the donor (effective) run for the cycle lookup so that the cycle
+    # filter in matchingCalibrationIndex works correctly.
+    _propagation_re = re.compile(r"\(copied from run:(\S+)\s+version:")
     for entry in calIndexList:
         if "cycleID" not in entry:
-            entry["cycleID"] = get_cycle_for_run(entry["runNumber"])
+            comment = entry.get("comments", "")
+            m = _propagation_re.match(comment)
+            effectiveRun = m.group(1) if m else entry["runNumber"]
+            entry["cycleID"] = get_cycle_for_run(effectiveRun)
 
     calStatus["calibIndexList"] = calIndexList
 


### PR DESCRIPTION
…alibrations

checkCalibrationStatus annotates each index entry with a cycleID by looking up the entry's runNumber.  For propagated calibrations the runNumber field still holds the recipient state's seed run, not the donor run that actually produced the calibration.  This caused matchingCalibrationIndex to reject valid propagated calibrations as 'out of cycle'.

Fix: extract the donor run from the propagation comment '(copied from run:<run> version:<ver>)' when present, and use that for the cycle lookup.

Reproducer: ssm.isCalibrated(69089) reported difcal out-of-cycle (2025-B) when the propagated calibration from run 68979 is in 2026-A.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
