### PR TITLE
Remove debug print for workspace names

### DIFF
--- a/src/snapwrap/utils.py
+++ b/src/snapwrap/utils.py
@@ -229,7 +229,6 @@ def filterLite(runNumber, boundaries, **reduce_kwargs):
         wsNames = reduce(runNumber=runNumber, **reduce_kwargs)
 
         # rename output workspace to indicate sequences
-        print(f"Debug: reduced workspace names are: {wsNames}")
         for name in wsNames:
             if "pixelmask" in name:
                 continue #if a pixel mask is used, SNAPRed returns its workspace name. Skip this as it's not a reduced workspace


### PR DESCRIPTION
Removed debug print statement for reduced workspace names.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
